### PR TITLE
Escape xml attributes in junit output

### DIFF
--- a/sap/cli/aunit.py
+++ b/sap/cli/aunit.py
@@ -68,12 +68,12 @@ def print_junit4(run_results, args, stream):
     """Print results to stream in the form of JUnit"""
 
     print('<?xml version="1.0" encoding="UTF-8" ?>', file=stream)
-    print(f'<testsuites name="{args.name}">', file=stream)
+    print(f'<testsuites name="{escape(args.name)}">', file=stream)
 
     critical = 0
     for program in run_results.programs:
         for test_class in program.test_classes:
-            print(f'  <testsuite name="{test_class.name}" package="{program.name}" \
+            print(f'  <testsuite name="{escape(test_class.name)}" package="{escape(program.name)}" \
 tests="{len(test_class.test_methods)}"', file=stream, end='')
 
             if not test_class.test_methods:
@@ -93,7 +93,7 @@ tests="{len(test_class.test_methods)}"', file=stream, end='')
                 else:
                     status = 'OK'
 
-                print(f'    <testcase name="{test_method.name}" classname="{test_class.name}" status="{status}"',
+                print(f'    <testcase name="{escape(test_method.name)}" classname="{escape(test_class.name)}" status="{escape(status)}"',
                       file=stream, end='')
 
                 if not test_method.alerts:
@@ -103,7 +103,7 @@ tests="{len(test_class.test_methods)}"', file=stream, end='')
                 print('>', file=stream)
 
                 for alert in test_method.alerts:
-                    print(f'      <error type="{alert.kind}" message="{alert.title}"', file=stream, end='')
+                    print(f'      <error type="{escape(alert.kind)}" message="{escape(alert.title)}"', file=stream, end='')
                     if not alert.details and not alert.stack:
                         print('/>', file=stream)
                         continue

--- a/sap/cli/aunit.py
+++ b/sap/cli/aunit.py
@@ -93,7 +93,8 @@ tests="{len(test_class.test_methods)}"', file=stream, end='')
                 else:
                     status = 'OK'
 
-                print(f'    <testcase name="{escape(test_method.name)}" classname="{escape(test_class.name)}" status="{escape(status)}"',
+                print(f'    <testcase name="{escape(test_method.name)}" classname="{escape(test_class.name)}" \
+status="{escape(status)}"',
                       file=stream, end='')
 
                 if not test_method.alerts:
@@ -103,7 +104,8 @@ tests="{len(test_class.test_methods)}"', file=stream, end='')
                 print('>', file=stream)
 
                 for alert in test_method.alerts:
-                    print(f'      <error type="{escape(alert.kind)}" message="{escape(alert.title)}"', file=stream, end='')
+                    print(f'      <error type="{escape(alert.kind)}" message="{escape(alert.title)}"',
+                          file=stream, end='')
                     if not alert.details and not alert.stack:
                         print('/>', file=stream)
                         continue


### PR DESCRIPTION
Our testrun managed to output an invalid XML because of `Runtime Error<LOAD_PROGRAM_CLASS_MISMATCH>` in one of the attributes:
```
  <testsuite name="CL_TEST" package="CL_IFME_BLOCK_PR_DELIMITED_ALT" tests="1">
    <testcase name="RUN_TEST" classname="CL_TEST" status="SKIP">
      <error type="runtimeAbortion" message="Runtime Error<LOAD_PROGRAM_CLASS_MISMATCH>">
        <system-out>[Class interface changed at runtime.]</system-out>
        <system-err>Include: &lt;CL_IFME_BLOCK_PR_ALTERNATIVE==CM003&gt; Line: &lt;7&gt;</system-err>
      </error>
      <error type="abortion" message="Navigation Link">
        <system-out>Show Runtime Error: JEZEK 20190524 105024</system-out>
      </error>
    </testcase>
  </testsuite>
```

*I did not run this, but you already use escape in elements, so this should be fine.*