### PR TITLE
Allow symlinks to be used

### DIFF
--- a/sapcli
+++ b/sapcli
@@ -10,7 +10,7 @@ import sys
 import importlib.util
 from importlib.machinery import SourceFileLoader
 
-base_dir = os.path.dirname(os.path.abspath(__file__))
+base_dir = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
 sys.path.append(base_dir)
 
 sapcli_bin = os.path.join(base_dir, 'bin', 'sapcli')


### PR DESCRIPTION
I have a docker image for sapcli in a private registry. sapcli is installed in /opt/sapcli and I symlinked /opt/sapcli/sapcli to /usr/bin/sapcli.

This didn't work because sapcli was looking for /usr/bin/bin/sapcli in an attempt to find /opt/sapcli/bin/sapcli ...

This should fix it.

```
$ sapcli --ashost $SAP_ASHOST --client $SAP_CLIENT --no-ssl --port $SAP_PORT --user $SAP_USER --password $SAP_PASSWORD aunit run class "/ABC/MY_CLASS" --output junit4 > report.xml && cat report.xml
Traceback (most recent call last):
  File "/usr/bin/sapcli", line 20, in <module>
    spec.loader.exec_module(sapcli)
  File "<frozen importlib._bootstrap_external>", line 724, in exec_module
  File "<frozen importlib._bootstrap_external>", line 859, in get_code
  File "<frozen importlib._bootstrap_external>", line 916, in get_data
FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/bin/sapcli'
```