### PR TITLE
Implement FLP initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ve/
 *.orig
 .coverage
 .htmlcov/
+.vscode/

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -15,3 +15,4 @@
 13. [checkout](commands/checkout.md) - Source Code Management System
 14. [datapreview](commands/datapreview.md) - Simple ABAP OSQL queries
 15. [startrfc](commands/startrfc.md) - Run arbitrary RFC enabled Function Modules
+16. [flp](commands/flp.md) - Fiori Launchpad

--- a/doc/commands/flp.md
+++ b/doc/commands/flp.md
@@ -1,0 +1,38 @@
+# Fiori Launchpad
+
+1. [init](#init)
+
+## init
+
+Initializes the Fiori Launchpad based on the YAML configuration file
+
+```bash
+sapcli flp init --config ./config.yml
+```
+
+Example configuration:
+
+```yaml
+catalogs:
+  - title: Custom Catalog
+    id: ZCUSTOM_CATALOG
+    target_mappings:
+      - title: My Reporting App
+        semantic_object: MyReporting
+        semantic_action: display
+        url: /sap/bc/ui5_ui5/sap/ZMY_REPORT # path to the BSP app on the SAP system
+        ui5_component: zmy.app.reporting # UI5 app id defined in manifest.json
+    tiles:
+      - title: My Reporting App
+        id: ZMY_REPORTING
+        icon: sap-icon://settings
+        semantic_object: MyReporting
+        semantic_action: display
+groups:
+  - title: Custom Group
+    id: ZCUSTOM_GROUP
+    tiles:
+      - title: My Reporting App
+        catalog_id: ZCUSTOM_CATALOG
+        catalog_tile_id: ZMY_REPORTING # this has to match one of the catalogs->tiles->id property
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests>=2.20.0
+pyodata==1.7.0
+PyYAML==5.4.1

--- a/sap/cli/__init__.py
+++ b/sap/cli/__init__.py
@@ -17,6 +17,7 @@ class CommandsCache:
     adt = None
     rfc = None
     rest = None
+    flp = None
 
     @staticmethod
     def commands():
@@ -40,6 +41,7 @@ class CommandsCache:
         import sap.cli.adt
         import sap.cli.strust
         import sap.cli.abapgit
+        import sap.cli.flp
 
         if CommandsCache.adt is None:
             CommandsCache.adt = [
@@ -75,7 +77,12 @@ class CommandsCache:
             else:
                 CommandsCache.rfc = list()
 
-        return CommandsCache.adt + CommandsCache.rest + CommandsCache.rfc
+        if CommandsCache.flp is None:
+            CommandsCache.flp = [
+                (flp_connection_from_args, sap.cli.flp.CommandGroup())
+            ]
+
+        return CommandsCache.adt + CommandsCache.rest + CommandsCache.rfc + CommandsCache.flp
 
 
 def adt_connection_from_args(args):
@@ -106,6 +113,16 @@ def gcts_connection_from_args(args):
     return sap.rest.Connection('sap/bc/cts_abapvcs', 'system', args.ashost, args.client,
                                args.user, args.password, port=args.port, ssl=args.ssl,
                                verify=args.verify)
+
+
+def flp_connection_from_args(args):
+    """Returns OData connection constructed from the passed args (Namespace)
+    """
+
+    import sap.odata
+    return sap.odata.Connection('UI2/PAGE_BUILDER_CUST', args.ashost, args.port,
+                                args.client, args.user, args.password, args.ssl,
+                                args.verify)
 
 
 def get_commands():

--- a/sap/cli/flp.py
+++ b/sap/cli/flp.py
@@ -1,0 +1,21 @@
+"""flp methods"""
+
+import sap.cli.core
+import sap.flp
+
+
+class CommandGroup(sap.cli.core.CommandGroup):
+    """Management for FLP Catalog"""
+
+    def __init__(self):
+        super().__init__('flp')
+
+
+@CommandGroup.argument('--config', type=str, required=True, help="Configuration file path")
+@CommandGroup.command()
+def init(connection, args):
+    """Initializes the Fiori Launchpad
+    """
+
+    builder = sap.flp.builder.Builder(connection, args.config)
+    builder.run()

--- a/sap/errors.py
+++ b/sap/errors.py
@@ -13,3 +13,16 @@ class SAPCliError(FatalError):
 
     # pylint: disable=unnecessary-pass
     pass
+
+
+class ResourceAlreadyExistsError(SAPCliError):
+    """Exception for existing resources - e.g. item to be created"""
+
+    # pylint: disable=unnecessary-pass
+    pass
+
+    def __repr__(self):
+        return 'Resource already exists'
+
+    def __str__(self):
+        return repr(self)

--- a/sap/flp/__init__.py
+++ b/sap/flp/__init__.py
@@ -1,0 +1,4 @@
+"""Fiori Launchpad wrappers and helpers"""
+
+from sap.flp.builder import Builder
+from sap.flp.service import Service

--- a/sap/flp/builder.py
+++ b/sap/flp/builder.py
@@ -1,0 +1,113 @@
+"""Fiori Launchpad initialization helper"""
+import yaml
+
+from sap import get_logger
+from sap.flp.service import Service
+
+
+class Builder:
+    """FLP business objects initializer"""
+
+    def __init__(self, connection, config_path):
+        self._service = self._create_service(connection)
+        self._config = self._load_config(config_path)
+
+    def run(self):
+        """Creates the business catalog"""
+
+        get_logger().info("Running the cleanup")
+
+        for catalog in self._config["catalogs"]:
+            self._build_catalog(catalog)
+
+        for group in self._config["groups"]:
+            self._buid_group(group, self._config["catalogs"])
+
+    def cleanup(self):
+        """Removes existing catalogs and groups according to the configuration"""
+
+        get_logger().info("Removing previously created catalogs")
+
+        for catalog in self._config["catalogs"]:
+            self._service.delete_catalog(catalog["id"])
+
+        get_logger().info("Removing previously created groups")
+
+        for group in self._config["groups"]:
+            self._service.delete_group(group["id"])
+
+    def _load_config(self, path):
+        with open(path, 'r') as stream:
+            return yaml.safe_load(stream)
+
+    def _create_service(self, connection):
+        return Service(connection)
+
+    def _build_catalog(self, catalog):
+        get_logger().info("Creating catalog: %s", catalog["title"])
+
+        self._service.create_catalog({
+            "domainId": catalog["id"],
+            "title": catalog["title"]
+        })
+
+        for target_mapping in catalog["target_mappings"]:
+            get_logger().info("Creating target mapping: %s", target_mapping["title"])
+
+            self._service.create_mapping(catalog["id"], {
+                "tileConfiguration": {
+                    "semantic_object": target_mapping["semantic_object"],
+                    "semantic_action": target_mapping["semantic_action"],
+                    "display_title_text": target_mapping["title"],
+                    "url": target_mapping["url"],
+                    "ui5_component": target_mapping["ui5_component"]
+                }
+            })
+
+        for tile in catalog["tiles"]:
+            get_logger().info("Creating tile: %s", tile["title"])
+
+            tile_reference = self._service.create_tile(catalog["id"], {
+                "id": tile["id"],
+                "tileConfiguration": {
+                    "display_icon_url": tile["icon"],
+                    "display_title_text": tile["title"],
+                    "display_subtitle_text": tile.get("subtitle", ""),
+                    "display_info_text": tile.get("info", ""),
+                    "navigation_semantic_object": tile["semantic_object"],
+                    "navigation_semantic_action": tile["semantic_action"],
+                    "navigation_target_url": tile.get("url", f'#{tile["semantic_object"]}-{tile["semantic_action"]}'),
+                },
+                "title": tile["title"]
+            })
+            tile["instance_id"] = tile_reference.instanceId
+
+    def _buid_group(self, group, catalogs):
+        get_logger().info("Creating group: %s", group["title"])
+
+        self._service.create_group({
+            "id": group["id"],
+            "title": group["title"]
+        })
+
+        for tile in group["tiles"]:
+            get_logger().info("Adding tile: %s", tile["title"])
+
+            catalog_tile = self._get_catalog_tile(catalogs, tile["catalog_id"], tile["catalog_tile_id"])
+
+            self._service.add_tile_to_group(
+                group_id=group["id"],
+                catalog_id=tile["catalog_id"],
+                tile_id=catalog_tile["instance_id"]
+            )
+
+    def _get_catalog_tile(self, catalogs, catalog_id, tile_id):
+        for catalog in catalogs:
+            if catalog["id"] == catalog_id:
+                break
+
+        for tile in catalog["tiles"]:
+            if tile["id"] == tile_id:
+                break
+
+        return tile

--- a/sap/flp/service.py
+++ b/sap/flp/service.py
@@ -1,0 +1,123 @@
+"""Fiori Launchpad initialization helper"""
+
+import json
+
+
+class Service:
+    """FLP business objects initializer"""
+
+    def __init__(self, connection):
+        self._connection = connection
+
+    def create_catalog(self, data):
+        """Creates a new business catalog"""
+
+        create_request = self._connection.client.entity_sets.Catalogs.create_entity()
+        create_request.set(
+            **data,
+            type="CATALOG_PAGE"
+        )
+
+        return create_request.execute()
+
+    def create_group(self, data):
+        """Creates a new applications group"""
+
+        create_request = self._connection.client.entity_sets.Pages.create_entity()
+        create_request.set(
+            **data,
+            catalogId="/UI2/FLPD_CATALOG",
+            layout=""
+        )
+
+        return create_request.execute()
+
+    def create_tile(self, catalog_id, data):
+        """Creates a new app tile"""
+
+        create_request = self._connection.client.entity_sets.PageChipInstances.create_entity()
+        create_request.set(
+            chipId="X-SAP-UI2-CHIP:/UI2/STATIC_APPLAUNCHER",
+            scope="CUSTOMIZING",
+            instanceId="",
+            layoutData="",
+            pageId=f"X-SAP-UI2-CATALOGPAGE:{catalog_id}",
+            title=data["title"],
+            configuration=json.dumps({
+                "id": data["id"],
+                "tileConfiguration": json.dumps({
+                    "navigation_use_semantic_object": True,
+                    "navigation_semantic_parameters": "",
+                    "display_search_keywords": "",
+                    **data["tileConfiguration"]
+                })
+            })
+        )
+
+        return create_request.execute()
+
+    def create_mapping(self, catalog_id, data):
+        """Creates a new target mapping"""
+
+        create_request = self._connection.client.entity_sets.PageChipInstances.create_entity()
+        create_request.set(
+            chipId="X-SAP-UI2-CHIP:/UI2/ACTION",
+            configuration=json.dumps({
+                "tileConfiguration": json.dumps({
+                    "navigation_provider": "SAPUI5",
+                    "navigation_provider_role": "",
+                    "navigation_provider_instance": "",
+                    "target_application_id": "",
+                    "target_application_alias": "",
+                    "transaction": {
+                        "code": ""
+                    },
+                    "web_dynpro": {
+                        "application": "",
+                        "configuration": ""
+                    },
+                    "target_system_alias": "",
+                    "display_info_text": "",
+                    "mapping_signature": "*=*",
+                    "signature": {
+                        "parameters": {
+                            "": {
+                                "required": False
+                            }
+                        },
+                        "additional_parameters": "allowed"
+                    },
+                    **data["tileConfiguration"]
+                })
+            }),
+            scope="CUSTOMIZING",
+            instanceId="",
+            layoutData="",
+            pageId=f"X-SAP-UI2-CATALOGPAGE:{catalog_id}",
+            title=""
+        )
+
+        return create_request.execute()
+
+    def add_tile_to_group(self, group_id, catalog_id, tile_id):
+        """Adds a tile to the group"""
+
+        create_request = self._connection.client.entity_sets.PageChipInstances.create_entity()
+        create_request.set(
+            chipId=f"X-SAP-UI2-PAGE:X-SAP-UI2-CATALOGPAGE:{catalog_id}:{tile_id}",
+            pageId=group_id
+        )
+
+        return create_request.execute()
+
+    def delete_catalog(self, catalog_id):
+        """Removes exising catalog"""
+
+        catalogs = self._connection.client.entity_sets.Catalogs.get_entities().filter(f"domainId eq '{catalog_id}'").execute()
+
+        for catalog in catalogs:
+            self._connection.client.entity_sets.Catalogs.delete_entity(key=catalog.entity_key).execute()
+
+    def delete_group(self, group_id):
+        """Removes existing group"""
+        self._connection.client.entity_sets.Pages.delete_entity(group_id).execute()

--- a/sap/odata/__init__.py
+++ b/sap/odata/__init__.py
@@ -1,0 +1,3 @@
+"""OData wrappers and helpers"""
+
+from sap.odata.connection import Connection  # noqa: F401

--- a/sap/odata/connection.py
+++ b/sap/odata/connection.py
@@ -1,0 +1,77 @@
+"""OData connection helpers"""
+
+import pyodata
+import requests
+from requests.auth import HTTPBasicAuth
+
+from sap import get_logger, config_get
+from sap.odata.errors import HTTPRequestError, UnauthorizedError, TimedOutRequestError
+
+
+# pylint: disable=too-many-instance-attributes,too-few-public-methods
+class Connection:
+    """OData communication built on top of pyodata and requests.
+    """
+
+    client = None
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, service, host, port, client, user, password, ssl, verify):
+        """Parameters:
+            - service: id of the odata service (e.g. ABAP_REPOSITORY_SRV)
+            - host: string host name or IP of
+            - port: string TCP/IP port for abap application server
+            - client: string SAP client
+            - user: string user name
+            - password: string user password
+            - ssl: boolean to switch between http and https
+            - verify: boolean to switch SSL validation on/off
+        """
+
+        if ssl:
+            protocol = 'https'
+            if port is None:
+                port = '443'
+        else:
+            protocol = 'http'
+            if port is None:
+                port = '80'
+
+        self._ssl_verify = verify
+
+        self._base_url = '{protocol}://{host}:{port}/sap/opu/odata/{service}'.format(
+            protocol=protocol, host=host, port=port, service=service)
+
+        self._query_args = 'sap-client={client}&saml2=disabled'.format(
+            client=client)
+
+        self._user = user
+        self._auth = HTTPBasicAuth(user, password)
+        self._session = None
+        self._timeout = config_get('http_timeout')
+
+        self._session = requests.Session()
+        self._session.verify = verify
+        self._session.auth = (user, password)
+
+        # csrf token handling for all future "create" requests
+        try:
+            get_logger().info('Executing head request as part of CSRF authentication %s', self._base_url)
+            req = requests.Request('HEAD', self._base_url, headers={'x-csrf-token': 'fetch'})
+            req = self._session.prepare_request(req)
+            res = self._session.send(req, timeout=self._timeout)
+
+        except requests.exceptions.ConnectTimeout:
+            raise TimedOutRequestError(req, self._timeout)
+
+        if res.status_code == 401:
+            raise UnauthorizedError(req, res, self._user)
+
+        if res.status_code >= 400:
+            raise HTTPRequestError(req, res)
+
+        token = res.headers.get('x-csrf-token', '')
+        self._session.headers.update({'x-csrf-token': token})
+
+        # instance of the service
+        self.client = pyodata.Client(self._base_url, self._session)

--- a/sap/odata/errors.py
+++ b/sap/odata/errors.py
@@ -1,0 +1,56 @@
+"""HTTP related errors"""
+
+from sap.errors import SAPCliError
+
+
+class HTTPRequestError(SAPCliError):
+    """Exception for unexpected HTTP responses"""
+
+    def __init__(self, request, response):
+        super().__init__()
+
+        self.request = request
+        self.response = response
+
+    def __repr__(self):
+        return f'{self.response.status_code}\n{self.response.text}'
+
+    def __str__(self):
+        return repr(self)
+
+
+class UnauthorizedError(SAPCliError):
+    """Exception for unauthorized """
+
+    def __init__(self, request, response, user):
+        super().__init__()
+
+        self.request = request
+        self.response = response
+        self.method = request.method
+        self.url = request.url
+        self.user = user
+
+    def __repr__(self):
+        return f'Authorization for the user "{self.user}" has failed: {self.method} {self.url}'
+
+    def __str__(self):
+        return repr(self)
+
+
+class TimedOutRequestError(SAPCliError):
+    """Exception for timeout requests"""
+
+    def __init__(self, request, timeout):
+        super().__init__()
+
+        self.request = request
+        self.method = request.method
+        self.url = request.url
+        self.timeout = timeout
+
+    def __repr__(self):
+        return f'The request {self.method} {self.url} took more than {self.timeout}s'
+
+    def __str__(self):
+        return repr(self)

--- a/test/unit/fixtures_flp_builder.py
+++ b/test/unit/fixtures_flp_builder.py
@@ -1,0 +1,25 @@
+# Standard configuration
+FLP_BUILDER_CONFIG = '''
+catalogs:
+  - title: Custom Catalog
+    id: ZCUSTOM_CATALOG
+    target_mappings:
+      - title: My Reporting App
+        semantic_object: MyReporting
+        semantic_action: display
+        url: /sap/bc/ui5_ui5/sap/ZMY_REPORT  # path to the BSP app on the SAP system
+        ui5_component: zmy.app.reporting # UI5 app id defined in manifest.json
+    tiles:
+      - title: My Reporting App
+        id: ZMY_REPORTING
+        icon: sap-icon://settings
+        semantic_object: MyReporting
+        semantic_action: display
+groups:
+  - title: Custom Group
+    id: ZCUSTOM_GROUP
+    tiles:
+      - title: My Reporting App
+        catalog_id: ZCUSTOM_CATALOG
+        catalog_tile_id: ZMY_REPORTING # this has to match one of the catalogs->tiles->id property
+'''

--- a/test/unit/test_sap_cli_flp.py
+++ b/test/unit/test_sap_cli_flp.py
@@ -1,0 +1,31 @@
+'''FLP CLI tests.'''
+#!/usr/bin/env python3
+
+# pylint: disable=protected-access,missing-function-docstring
+
+import unittest
+import sap.cli.flp
+from unittest.mock import MagicMock, Mock, mock_open, patch
+from fixtures_flp_builder import FLP_BUILDER_CONFIG
+
+
+def get_sample_init_args():
+    args = Mock()
+    args.config = "config"
+    return args
+
+
+@patch('builtins.open', mock_open(read_data=FLP_BUILDER_CONFIG))
+class TestFlpCommands(unittest.TestCase):
+    '''Test FLP cli commands'''
+
+    @patch('sap.flp.builder.Builder', autospec=True)
+    def test_init_ok(self, builder_mock):
+        connection = MagicMock()
+
+        builder_mock.return_value.run.return_value = None
+
+        sap.cli.flp.init(connection, get_sample_init_args())
+
+        builder_mock.assert_called_with(connection, "config")
+        builder_mock.return_value.run.assert_called()

--- a/test/unit/test_sap_flp_builder.py
+++ b/test/unit/test_sap_flp_builder.py
@@ -1,0 +1,109 @@
+'''FLP Builder tests.'''
+#!/usr/bin/env python3
+
+# pylint: disable=protected-access,missing-function-docstring
+
+import json
+import yaml
+import unittest
+from unittest.mock import MagicMock, Mock, PropertyMock, call, mock_open, patch
+from sap.flp.builder import Builder
+from fixtures_flp_builder import FLP_BUILDER_CONFIG
+
+
+@patch('builtins.open', mock_open(read_data=FLP_BUILDER_CONFIG))
+class TestFlpBuilder(unittest.TestCase):
+    '''Test FLP Builder'''
+
+    def test_init_ok(self):
+        connection = MagicMock()
+        instance = Builder(connection, "config")
+
+        self.assertDictEqual(instance._config, yaml.safe_load(FLP_BUILDER_CONFIG))
+        open.assert_called_with("config", "r")
+
+    def test_cleanup_ok(self):
+        def get_catalogs():
+            catalogs = [Mock(), Mock()]
+            catalogs[0].entity_key = "C1"
+            catalogs[1].entity_key = "C2"
+            return catalogs
+
+        connection = MagicMock()
+        instance = Builder(connection, "config")
+
+        connection.client.entity_sets.Catalogs.get_entities().filter().execute.side_effect = get_catalogs
+        connection.client.entity_sets.Pages.delete_entity().execute = Mock()
+
+        instance.cleanup()
+
+        catalog_calls = connection.client.entity_sets.Catalogs.delete_entity.call_args_list
+
+        self.assertIn(call(key="C1"), catalog_calls)
+        self.assertIn(call(key="C2"), catalog_calls)
+
+        connection.client.entity_sets.Pages.delete_entity.assert_called_with("ZCUSTOM_GROUP")
+
+    def test_run_ok(self):
+        def create_tile():
+            tile_instance = Mock()
+            tile_instance.instanceId = "TILE_ID"
+            return tile_instance
+
+        connection = MagicMock()
+        instance = Builder(connection, "config")
+
+        connection.client.entity_sets.PageChipInstances.create_entity().execute.side_effect = create_tile
+
+        instance.run()
+
+        # Create catalog
+        connection.client.entity_sets.Catalogs.create_entity().set.assert_called_with(
+            domainId="ZCUSTOM_CATALOG",
+            title="Custom Catalog",
+            type="CATALOG_PAGE"
+        )
+
+        # Create group
+        connection.client.entity_sets.Pages.create_entity().set.assert_called_with(
+            id="ZCUSTOM_GROUP",
+            title="Custom Group",
+            catalogId="/UI2/FLPD_CATALOG",
+            layout=""
+        )
+
+        page_chip_instance_calls = connection.client.entity_sets.PageChipInstances.create_entity().set.call_args_list
+
+        # Create target mapping
+        args, kwargs = page_chip_instance_calls[0]
+        tile_config = json.loads(json.loads(kwargs["configuration"])["tileConfiguration"])
+
+        self.assertEqual(kwargs["chipId"], "X-SAP-UI2-CHIP:/UI2/ACTION")
+        self.assertEqual(kwargs["pageId"], "X-SAP-UI2-CATALOGPAGE:ZCUSTOM_CATALOG")
+        self.assertEqual(tile_config["navigation_provider"], "SAPUI5")
+        self.assertEqual(tile_config["semantic_object"], "MyReporting")
+        self.assertEqual(tile_config["semantic_action"], "display")
+        self.assertEqual(tile_config["display_title_text"], "My Reporting App")
+        self.assertEqual(tile_config["url"], "/sap/bc/ui5_ui5/sap/ZMY_REPORT")
+        self.assertEqual(tile_config["ui5_component"], "zmy.app.reporting")
+
+        # Create tile
+        args, kwargs = page_chip_instance_calls[1]
+        tile_config = json.loads(json.loads(kwargs["configuration"])["tileConfiguration"])
+
+        self.assertEqual(kwargs["chipId"], "X-SAP-UI2-CHIP:/UI2/STATIC_APPLAUNCHER")
+        self.assertEqual(kwargs["pageId"], "X-SAP-UI2-CATALOGPAGE:ZCUSTOM_CATALOG")
+        self.assertEqual(kwargs["title"], "My Reporting App")
+        self.assertEqual(tile_config["navigation_use_semantic_object"], True)
+        self.assertEqual(tile_config["display_icon_url"], "sap-icon://settings")
+        self.assertEqual(tile_config["display_title_text"], "My Reporting App")
+        self.assertEqual(tile_config["display_subtitle_text"], "")
+        self.assertEqual(tile_config["display_info_text"], "")
+        self.assertEqual(tile_config["navigation_semantic_object"], "MyReporting")
+        self.assertEqual(tile_config["navigation_semantic_action"], "display")
+        self.assertEqual(tile_config["navigation_target_url"], "#MyReporting-display")
+
+        # Add tile to group
+        args, kwargs = page_chip_instance_calls[2]
+        self.assertEqual(kwargs["chipId"], "X-SAP-UI2-PAGE:X-SAP-UI2-CATALOGPAGE:ZCUSTOM_CATALOG:TILE_ID")
+        self.assertEqual(kwargs["pageId"], "ZCUSTOM_GROUP")


### PR DESCRIPTION
Initial implementation of the Fiori Launchpad configuration module.

This PR reuses some functionality of the #35 (eg. odata connection). Once either of these is merged the second one will be rebased on top of it.

Currently the only supported FLP operation (from the command line perspective) is "init" - fetch the configuration and create specified business objects (catalog, group, target mapping, tiles...).

More functionality can be added when needed. However there are some technical limitations of the FLP odata service that cannot be bypassed.