### PR TITLE
bsp: full implementation

### DIFF
--- a/doc/commands/bsp.md
+++ b/doc/commands/bsp.md
@@ -1,22 +1,50 @@
 # BSP Applications
 
-1. [create](#create)
+1. [upload](#upload)
+2. [stat](#stat)
+3. [delete](#delete)
 
-## create
+## upload
 
-Creates new BSP application `APP123` in package `SOME_PACKAGE` and uploads
-packed javascript sources. Be aware of:
+Uploads the packed javascript sources for the BSP application `APP123` in package `SOME_PACKAGE`.
+Be aware of:
+
 * package and transport have to exist.
 * zipped application codebase have to be preprocessed (minified), e.g. by
   [`@sap/ux-ui5-tooling`](https://www.npmjs.com/package/@sap/ux-ui5-tooling)
-* it is not possible to upload zipped codebase to existing appllication yet
-  (application cannot exist).
+* if the application does not exist yet, it will be created automatically
 
 ```bash
-sapcli bsp create \
+sapcli bsp upload \
     --app=/some/dire/app.zip \
     --package=SOME_PACKAGE \
     --bsp=APP123 \
     --corrnr=C50K000167 \
 ```
 
+## stat
+
+Prints basic set of BSP application attributes. Returned exit could be interpreted as:
+
+* `0` - application found
+* `10` - application not found
+
+```bash
+sapcli bsp stat --bsp=APP123
+```
+
+which results in output similar to:
+
+```
+Name                   :APP123
+Package                :SOME_PACKAGE
+Description            :Application Description
+```
+
+## delete
+
+Deletes a BSP application
+
+```bash
+sapcli bsp delete --bsp=APP123 --corrnr=C50K000167
+```

--- a/sap/cli/bsp.py
+++ b/sap/cli/bsp.py
@@ -73,3 +73,26 @@ def create(connection, args):
         raise ex
 
     get_logger().info('BSP application successfully created and uploaded')
+
+
+@CommandGroup.argument('--bsp', type=str, required=True, help='BSP ID')
+@CommandGroup.command()
+def stat(connection, args):
+    """Get information about BSP application"""
+
+    console = sap.cli.core.get_console()
+
+    # check if application exists
+    try:
+        bsp = connection.client.entity_sets.Repositories.get_entity(Name=args.bsp).execute()
+    except pyodata.exceptions.HttpError as ex:
+        if ex.response.status_code == 404:
+            return sap.cli.core.EXIT_CODE_NOT_FOUND
+        else:
+            raise ex
+
+    console.printout(f'Name                   :{bsp.Name}')
+    console.printout(f'Package                :{bsp.Package}')
+    console.printout(f'Description            :{bsp.Description}')
+
+    return sap.cli.core.EXIT_CODE_OK

--- a/sap/cli/bsp.py
+++ b/sap/cli/bsp.py
@@ -96,3 +96,24 @@ def stat(connection, args):
     console.printout(f'Description            :{bsp.Description}')
 
     return sap.cli.core.EXIT_CODE_OK
+
+
+@CommandGroup.argument('--bsp', type=str, required=True, help='BSP ID')
+@CommandGroup.argument('--corrnr', type=str, required=True,
+                       help='Transport Request to be used for application removal')
+@CommandGroup.command()
+def delete(connection, args):
+    """Get information about BSP application"""
+
+    try:
+        connection.client \
+            .entity_sets \
+            .Repositories \
+            .delete_entity(Name=args.bsp) \
+            .custom('TransportRequest', args.corrnr) \
+            .execute()
+    except pyodata.exceptions.HttpError as ex:
+        if ex.response.status_code != 404:
+            raise ex
+
+    get_logger().info('BSP application successfully removed')

--- a/test/unit/test_sap_cli_bsp.py
+++ b/test/unit/test_sap_cli_bsp.py
@@ -21,30 +21,45 @@ def get_sample_create_args():
     return args
 
 
+def get_sample_stat_args():
+    args = Mock()
+    args.bsp = 'BSP'
+    return args
+
+
+def get_sample_delete_args():
+    args = Mock()
+    args.bsp = 'BSP'
+    args.corrnr = 'TREQ'
+    return args
+
+
 class TestBspCommands(unittest.TestCase):
     '''Test BSP cli commands'''
 
     @patch('builtins.open', mock_open(read_data=b'SOME_DATA'))
-    def test_create_ok(self):
+    def test_upload_create_ok(self):
         resp = Mock()
         resp.status_code = 404
         connection = MagicMock()
         connection.client.entity_sets.Repositories.get_entity().execute = Mock(
             side_effect=HttpError('MSG', resp))
 
-        sap.cli.bsp.create(connection, get_sample_create_args())
+        sap.cli.bsp.upload(connection, get_sample_create_args())
 
         connection.client.entity_sets.Repositories.create_entity.assert_called_once()
 
     @patch('builtins.open', mock_open(read_data=b'SOME_DATA'))
-    def test_create_already_exist(self):
+    def test_upload_update_ok(self):
         connection = MagicMock()
+        connection.client.entity_sets.Repositories.get_entity().execute = Mock()
 
-        with self.assertRaises(ResourceAlreadyExistsError):
-            sap.cli.bsp.create(connection, get_sample_create_args())
+        sap.cli.bsp.upload(connection, get_sample_create_args())
+
+        connection.client.entity_sets.Repositories.update_entity.assert_called_once()
 
     @patch('builtins.open', mock_open(read_data=b'SOME_DATA'))
-    def test_create_http_error(self):
+    def test_upload_http_error(self):
         resp = Mock()
         resp.status_code = 400
         connection = MagicMock()
@@ -52,27 +67,85 @@ class TestBspCommands(unittest.TestCase):
             side_effect=HttpError('MSG', resp))
 
         with self.assertRaises(HttpError):
-            sap.cli.bsp.create(connection, get_sample_create_args())
+            sap.cli.bsp.upload(connection, get_sample_create_args())
 
     @patch('logging.getLogger', return_value=MagicMock())
     @patch('builtins.open', mock_open(read_data=b'SOME_DATA'))
-    def test_create_error_creating(self, log_patch):
+    def test_upload_error_creating(self, log_patch):
         resp = Mock()
         resp.status_code = 404
         resp.text = '{"a":"b"}'
         connection = MagicMock()
         connection.client.entity_sets.Repositories.get_entity().execute = Mock(
             side_effect=HttpError('MSG', resp))
-        create_request = connection.client.entity_sets.Repositories.create_entity().custom().custom().custom()
+        create_request = connection.client.entity_sets.Repositories.create_entity()
         create_request.execute = Mock(side_effect=HttpError('MSG', resp))
 
         with self.assertRaises(HttpError):
-            sap.cli.bsp.create(connection, get_sample_create_args())
+            sap.cli.bsp.upload(connection, get_sample_create_args())
 
-        create_request.set.assert_called_once_with(**{
+        create_request.custom().custom().custom().set.assert_called_once_with(**{
             'Name': 'BSP',
             'Package': 'PKG',
             'ZipArchive': base64.b64encode(b'SOME_DATA').decode('utf8')
         })
 
-        log_patch.return_value.info.assert_called_once_with("{'a': 'b'}")
+        log_patch.return_value.info.assert_called_with("{'a': 'b'}")
+
+    def test_stat_ok(self):
+        connection = MagicMock()
+        connection.client.entity_sets.Repositories.get_entity().execute = Mock()
+
+        result = sap.cli.bsp.stat(connection, get_sample_stat_args())
+
+        self.assertEqual(result, 0)
+
+    def test_stat_not_found(self):
+        resp = Mock()
+        resp.status_code = 404
+        connection = MagicMock()
+        connection.client.entity_sets.Repositories.get_entity().execute = Mock(
+            side_effect=HttpError('MSG', resp))
+
+        result = sap.cli.bsp.stat(connection, get_sample_stat_args())
+
+        self.assertEqual(result, 10)
+
+    def test_stat_http_error(self):
+        resp = Mock()
+        resp.status_code = 500
+        connection = MagicMock()
+        connection.client.entity_sets.Repositories.get_entity().execute = Mock(
+            side_effect=HttpError('MSG', resp))
+
+        with self.assertRaises(HttpError):
+            sap.cli.bsp.stat(connection, get_sample_create_args())
+
+    def test_delete_ok(self):
+        connection = MagicMock()
+        connection.client.entity_sets.Repositories.delete_entity().custom().execute = Mock()
+
+        sap.cli.bsp.delete(connection, get_sample_delete_args())
+
+        self.assertEqual(connection.client.entity_sets.Repositories.delete_entity.call_count, 2)
+
+    def test_delete_not_found(self):
+        resp = Mock()
+        resp.status_code = 404
+        connection = MagicMock()
+        connection.client.entity_sets.Repositories.delete_entity().custom().execute = Mock(
+            side_effect=HttpError('MSG', resp))
+
+        sap.cli.bsp.delete(connection, get_sample_delete_args())
+
+        self.assertEqual(connection.client.entity_sets.Repositories.delete_entity.call_count, 2)
+
+    def test_delete_http_error(self):
+        resp = Mock()
+        resp.status_code = 500
+        connection = MagicMock()
+        connection.client.entity_sets.Repositories.delete_entity().custom().execute = Mock(
+            side_effect=HttpError('MSG', resp))
+
+        with self.assertRaises(HttpError):
+            sap.cli.bsp.delete(connection, get_sample_delete_args())


### PR DESCRIPTION
Added missing commands to control the BSP app:
* `stat`: get app attributes (or corresponding exit code if resource does not exist)
* `delete`: remove app
* `upload`: performs create/update request based on resource existence

Removed `create` command as this functionality is now handled by `upload`
