### PR TITLE
Enhance error output - add exception type

### DIFF
--- a/bin/sapcli
+++ b/bin/sapcli
@@ -121,7 +121,7 @@ def main(argv):
     except KeyboardInterrupt:
         log.error('Program interrupted!')
     except sap.errors.SAPCliError as ex:
-        print('Exception:', file=sys.stderr)
+        print(f'Exception ({type(ex).__name__}):', file=sys.stderr)
         print(' ', str(ex), file=sys.stderr)
         log.debug('Execution of program has been terminated due to an error', exc_info=True)
     finally:


### PR DESCRIPTION
The motivation for this is case, where remote server provides wrong or
misleading error description, which doesn't explain what really happened
and what is the root cause. Sapcli can handle such cases, but it stores
this information only as proper exception type. If the exception type
isn't printed out, this information is lost.

The example is creation of the function group via ADT, where creation
operation fails in case the function group already exists. ADT provides
completely wrong error message as a response.