### PR TITLE
Fix XML encoding of workbench task object descriptions

### DIFF
--- a/sap/adt/cts.py
+++ b/sap/adt/cts.py
@@ -3,6 +3,7 @@
 import re
 import xml.sax
 from xml.sax.handler import ContentHandler
+from xml.sax.saxutils import escape
 
 from typing import NamedTuple, Any, List
 
@@ -422,7 +423,7 @@ class WorkbenchTask(AbstractWorkbenchRequest):
             body=f'''<?xml version="1.0" encoding="ASCII"?>
 <tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" tm:number="{self._number}" tm:useraction="removeobject">
   <tm:request>
-    <tm:abap_object tm:name="{obj.name}" tm:obj_desc="{obj.description}" tm:pgmid="{obj.pgmid}" tm:type="{obj.type}" tm:position="{obj.position}"/>
+    <tm:abap_object tm:name="{obj.name}" tm:obj_desc="{escape(obj.description)}" tm:pgmid="{obj.pgmid}" tm:type="{obj.type}" tm:position="{obj.position}"/>
   </tm:request>
 </tm:root>''')
 

--- a/sap/rest/connection.py
+++ b/sap/rest/connection.py
@@ -117,6 +117,9 @@ class Connection:
 
         mod_log().info('Executing %s %s', method, url)
 
+        if body is not None:
+            mod_log().info('Body %s ', body)
+
         try:
             res = session.send(req, timeout=self._timeout)
         except requests.exceptions.ConnectTimeout as ex:

--- a/test/unit/test_sap_adt_cts.py
+++ b/test/unit/test_sap_adt_cts.py
@@ -5,6 +5,7 @@ import unittest
 from unittest.mock import patch, Mock
 from functools import partial
 import xml.sax
+from xml.sax.saxutils import escape
 
 import sap.adt.cts
 from sap.adt.cts import Element
@@ -278,7 +279,7 @@ class TestADTCTSWorkbenchRequestSetup(unittest.TestCase):
             type='CLAS',
             name='CL_BAR',
             wbtype='CLAS/CC',
-            description='just another class',
+            description='just another class & special char inside',
             locked=True,
             position='000001'
         )
@@ -422,7 +423,7 @@ class TestADTCTSWorkbenchRequestDelete(TestADTCTSWorkbenchRequestSetup):
                     body=f'''<?xml version="1.0" encoding="ASCII"?>
 <tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" tm:number="NPLK007001" tm:useraction="removeobject">
   <tm:request>
-    <tm:abap_object tm:name="{self.object_1_1.name}" tm:obj_desc="{self.object_1_1.description}" tm:pgmid="{self.object_1_1.pgmid}" tm:type="{self.object_1_1.type}" tm:position="{self.object_1_1.position}"/>
+    <tm:abap_object tm:name="{self.object_1_1.name}" tm:obj_desc="{escape(self.object_1_1.description)}" tm:pgmid="{self.object_1_1.pgmid}" tm:type="{self.object_1_1.type}" tm:position="{self.object_1_1.position}"/>
   </tm:request>
 </tm:root>'''
                 ),
@@ -431,7 +432,7 @@ class TestADTCTSWorkbenchRequestDelete(TestADTCTSWorkbenchRequestSetup):
                     body=f'''<?xml version="1.0" encoding="ASCII"?>
 <tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" tm:number="NPLK007001" tm:useraction="removeobject">
   <tm:request>
-    <tm:abap_object tm:name="{self.object_1_2.name}" tm:obj_desc="{self.object_1_2.description}" tm:pgmid="{self.object_1_2.pgmid}" tm:type="{self.object_1_2.type}" tm:position="{self.object_1_2.position}"/>
+    <tm:abap_object tm:name="{self.object_1_2.name}" tm:obj_desc="{escape(self.object_1_2.description)}" tm:pgmid="{self.object_1_2.pgmid}" tm:type="{self.object_1_2.type}" tm:position="{self.object_1_2.position}"/>
   </tm:request>
 </tm:root>'''
                 ),
@@ -441,7 +442,7 @@ class TestADTCTSWorkbenchRequestDelete(TestADTCTSWorkbenchRequestSetup):
                     body=f'''<?xml version="1.0" encoding="ASCII"?>
 <tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" tm:number="NPLK007002" tm:useraction="removeobject">
   <tm:request>
-    <tm:abap_object tm:name="{self.object_2_1.name}" tm:obj_desc="{self.object_2_1.description}" tm:pgmid="{self.object_2_1.pgmid}" tm:type="{self.object_2_1.type}" tm:position="{self.object_2_1.position}"/>
+    <tm:abap_object tm:name="{self.object_2_1.name}" tm:obj_desc="{escape(self.object_2_1.description)}" tm:pgmid="{self.object_2_1.pgmid}" tm:type="{self.object_2_1.type}" tm:position="{self.object_2_1.position}"/>
   </tm:request>
 </tm:root>'''
                 ),
@@ -450,7 +451,7 @@ class TestADTCTSWorkbenchRequestDelete(TestADTCTSWorkbenchRequestSetup):
                     body=f'''<?xml version="1.0" encoding="ASCII"?>
 <tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" tm:number="NPLK007002" tm:useraction="removeobject">
   <tm:request>
-    <tm:abap_object tm:name="{self.object_2_2.name}" tm:obj_desc="{self.object_2_2.description}" tm:pgmid="{self.object_2_2.pgmid}" tm:type="{self.object_2_2.type}" tm:position="{self.object_2_2.position}"/>
+    <tm:abap_object tm:name="{self.object_2_2.name}" tm:obj_desc="{escape(self.object_2_2.description)}" tm:pgmid="{self.object_2_2.pgmid}" tm:type="{self.object_2_2.type}" tm:position="{self.object_2_2.position}"/>
   </tm:request>
 </tm:root>'''
                 ),

--- a/test/unit/test_sap_odata_connection.py
+++ b/test/unit/test_sap_odata_connection.py
@@ -27,7 +27,7 @@ class TestConnection(unittest.TestCase):
 
         con = Connection('SERVICE', 'HOST', 'PORT', 'CLIENT', 'USER', 'PASSWORD', True, True)
 
-        url = 'https://HOST:PORT/sap/opu/odata/UI5/SERVICE'
+        url = 'https://HOST:PORT/sap/opu/odata/SERVICE'
         self.assertEqual(con._base_url, url)
         self.assertEqual(con._query_args, 'sap-client=CLIENT&saml2=disabled')
         self.assertEqual(con._user, 'USER')
@@ -53,7 +53,7 @@ class TestConnection(unittest.TestCase):
 
         con = Connection('SERVICE', 'HOST', None, 'CLIENT', 'USER', 'PASSWORD', True, True)
 
-        self.assertEqual(con._base_url, 'https://HOST:443/sap/opu/odata/UI5/SERVICE')
+        self.assertEqual(con._base_url, 'https://HOST:443/sap/opu/odata/SERVICE')
         request_patch.assert_called_once()
         client_patch.assert_called_once()
 
@@ -68,7 +68,7 @@ class TestConnection(unittest.TestCase):
 
         con = Connection('SERVICE', 'HOST', None, 'CLIENT', 'USER', 'PASSWORD', False, True)
 
-        self.assertEqual(con._base_url, 'http://HOST:80/sap/opu/odata/UI5/SERVICE')
+        self.assertEqual(con._base_url, 'http://HOST:80/sap/opu/odata/SERVICE')
         request_patch.assert_called_once()
         client_patch.assert_called_once()
 


### PR DESCRIPTION
* Tested against real system (recursive delete of big transport with nested tasks and 193 objects with special chars. in descriptions)
* Two additional things - minor fix of unit tests solving some rests from the past + logging of ADT request bodies