### PR TITLE
Add pyrfc connection to ADT: 1. Minor general fixes

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,6 @@
 coverage>=5.4
 pylint>=2.6.0
 flake8>=3.8.4
+mypy>=0.930
+types-PyYAML>=6.0.1
+types-requests>=2.26.2

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+disable_error_code = no-redef, import

--- a/sap/adt/acoverage_statements.py
+++ b/sap/adt/acoverage_statements.py
@@ -1,7 +1,7 @@
 """ABAP Unit Test Coverage framework code highlighting wrappers"""
 import xml
 from typing import NamedTuple, List
-from xml.sax import ContentHandler
+from xml.sax.handler import ContentHandler
 
 from sap import get_logger
 from sap.adt.annotations import OrderedClassMembers, xml_attribute, xml_element

--- a/sap/adt/cts.py
+++ b/sap/adt/cts.py
@@ -5,7 +5,7 @@ import xml.sax
 from xml.sax.handler import ContentHandler
 from xml.sax.saxutils import escape
 
-from typing import NamedTuple, Any, List
+from typing import NamedTuple, Any, List, Tuple
 
 from sap import get_logger
 from sap.errors import SAPCliError
@@ -169,7 +169,7 @@ class AbstractWorkbenchRequest:
 
         return f'cts/transportrequests/{self._number}'
 
-    def _create_request(self) -> (str, str):
+    def _create_request(self) -> Tuple[str, str]:
         """Returns a tuple (CTS URI request, XML content)"""
 
         raise NotImplementedError

--- a/sap/config.py
+++ b/sap/config.py
@@ -1,9 +1,10 @@
 """Configuration"""
 
 import os
+from typing import Any
 
 
-def config_get(option: str, default: str = None) -> str:
+def config_get(option: str, default: Any = None) -> Any:
     """Returns configuration values"""
 
     config = {'http_timeout': float(os.environ.get('SAPCLI_HTTP_TIMEOUT', 900))}

--- a/sap/rest/connection.py
+++ b/sap/rest/connection.py
@@ -37,10 +37,12 @@ def setup_keepalive():
 
     # Special thanks to: https://www.finbourne.com/blog/the-mysterious-hanging-client-tcp-keep-alives
     # This may cause problems in Windows!
-    HTTPConnection.default_socket_options = HTTPConnection.default_socket_options + [
-        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-        (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
-    ]
+    if "TCP_KEEPIDLE" in dir(socket):
+        # pylint: disable=no-member
+        HTTPConnection.default_socket_options = HTTPConnection.default_socket_options + [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+            (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
+        ]
 
 
 # pylint: disable=too-many-instance-attributes

--- a/sap/rfc/core.py
+++ b/sap/rfc/core.py
@@ -1,14 +1,14 @@
 """Base RFC functionality"""
 
 
-from typing import Dict
+from typing import Any, Dict
 
 import sap
 import sap.errors
 
 
-RFCParams = Dict[str, str]
-RFCResponse = Dict[str, str]
+RFCParams = Dict[str, Any]
+RFCResponse = Dict[str, Any]
 
 
 SAPRFC_MODULE = None

--- a/sap/rfc/user.py
+++ b/sap/rfc/user.py
@@ -2,7 +2,7 @@
 
 import datetime
 
-from typing import Dict, Union, List
+from typing import Dict, Optional, Union, List
 
 from sap.rfc.core import RFCParams
 from sap.rfc.bapi import (
@@ -179,7 +179,7 @@ class UserBuilder:
     def build_rfc_params(self) -> RFCParams:
         """Creates RFC parameters for Creating users"""
 
-        params = {}
+        params: RFCParams = {}
 
         self._rfc_params_add_username(params)
 
@@ -205,7 +205,7 @@ class UserBuilder:
     def build_change_rfc_params(self) -> RFCParams:
         """Create RFC parameters fro Updating user"""
 
-        params = {}
+        params: RFCParams = {}
         self._rfc_params_add_username(params)
 
         if self._password:
@@ -228,7 +228,7 @@ class UserRoleAssignmentBuilder:
         self._roles = role_names
         return self
 
-    def build_rfc_params(self) -> RFCParams:
+    def build_rfc_params(self) -> Optional[RFCParams]:
         """Creates RFC parameters"""
 
         if not self._roles:
@@ -263,7 +263,7 @@ class UserProfileAssignmentBuilder:
         self._profiles = profile_names
         return self
 
-    def build_rfc_params(self) -> RFCParams:
+    def build_rfc_params(self) -> Optional[RFCParams]:
         """Creates RFC parameters"""
 
         if not self._profiles:
@@ -303,13 +303,13 @@ class UserManager:
                                       'BAPI_USER_GET_DETAIL',
                                       {'USERNAME': username})
 
-    def create_user(self, connection, user_builder: UserBuilder) -> UserId:
+    def create_user(self, connection, user_builder: UserBuilder) -> BAPIReturn:
         """Creates a new user for the given user data"""
 
         rfc_ret = self._call_bapi_method(connection, 'BAPI_USER_CREATE1', user_builder.build_rfc_params())
         return BAPIReturn(rfc_ret['RETURN'])
 
-    def change_user(self, connection, user_builder: UserBuilder) -> UserId:
+    def change_user(self, connection, user_builder: UserBuilder) -> BAPIReturn:
         """Updates user with the given user data"""
 
         rfc_ret = self._call_bapi_method(connection, 'BAPI_USER_CHANGE', user_builder.build_change_rfc_params())

--- a/test/unit/test_sap_cli_object.py
+++ b/test/unit/test_sap_cli_object.py
@@ -120,7 +120,7 @@ class TestCommandGroupObjectTemplate(unittest.TestCase):
 
     @property
     def group(self):
-        return sefl.__class__.group
+        return self.__class__.group
 
     def setUp(self):
         self.group._init_mocks()
@@ -429,7 +429,7 @@ class TestCommandGroupObjectMaster(unittest.TestCase):
 
     @property
     def group(self):
-        return sefl.__class__.group
+        return self.__class__.group
 
     def setUp(self):
         self.group._init_mocks()


### PR DESCRIPTION
I plan to add to `sapcli` the ability to use ADT via `pyrfc` and RFC function `SADT_REST_RFC_ENDPOINT` instead of HTTP. 

This would allow using `sapcli` with Netweaver servers where the HTTP port is firewalled or with SAP's secure login client for authentication.

I plan to do this in three PRs. In this PR I address minor general issues. In the second, I will expose the parameters of `pyrfc.Connection` to the cli, and in the third, I will add the ability to choose a connection based on pyrfc to `sap.adt`.

In this pull request 
- I made the fix in `sap/rest/connection.py` conditional as `socket.TCP_KEEPIDLE` is not available on macOS and will lead to an error,
- ran `mypy sap` to check typing and corrected it in some places,
- fixed a typo in `test/unit/test_sap_cli_object.py`

`pylint` still gives me some errors, mostly `consider-using-f-string` warnings.