### PR TITLE
Add pyrfc connection to ADT: 2. Expose pyrfc parameters to cli

### DIFF
--- a/bin/sapcli
+++ b/bin/sapcli
@@ -8,7 +8,6 @@ import logging
 from argparse import ArgumentParser
 import getpass
 
-
 import sap
 import sap.cli
 import sap.adt
@@ -72,6 +71,22 @@ def parse_command_line(argv):
         '--password', dest='password', type=str, default=None,
         help='Password')
 
+    arg_parser.add_argument("--mshost", default=os.getenv("SAP_MSHOST"), help="Message server address (if connecting "
+                                                                              "via a load balancer)")
+    arg_parser.add_argument("--msserv", default=os.getenv("SAP_MSSERV"), help="Message server port")
+    arg_parser.add_argument("--sysid", default=os.getenv("SAP_SYSID"), help="System ID (use if connecting via a "
+                                                                            "message server")
+    arg_parser.add_argument("--group", default=os.getenv("SAP_GROUP"), help="Group (use if connecting via a message "
+                                                                            "server")
+    arg_parser.add_argument("--snc_qop", default=os.getenv("SNC_QOP"), help="SAP Secure Login Client QOP")
+    arg_parser.add_argument("--snc_myname", default=os.getenv("SNC_MYNAME"), help="SAP Secure Login Client MyName")
+    arg_parser.add_argument("--snc_partnername",
+                            default=os.getenv("SNC_PARTNERNAME"), help="SAP Secure Login Client Partner name")
+    arg_parser.add_argument("--snc_lib", default=os.getenv("SNC_LIB"),
+                            help="SAP Secure Login Client library (e.g. "
+                                 "/Applications/Secure Login Client.app/Contents/MacOS/lib/libsapcrypto.dylib")
+
+
     subparsers = arg_parser.add_subparsers()
     # pylint: disable=not-an-iterable
     for connection, cmd in sap.cli.get_commands():
@@ -89,23 +104,28 @@ def parse_command_line(argv):
 
     sap.cli.resolve_default_connection_values(args)
 
-    if not args.ashost:
+    if not args.ashost and not args.mshost:
         report_args_error_and_exit(
-            arg_parser,
-            ': '.join(('No SAP Application Server Host name provided',
-                       'use the option --ashost or the environment variable SAP_ASHOST')))
+            arg_parser, ': '.join((
+                'No SAP Application Server Host name provided',
+                'use the option --ashost or the environment variable SAP_ASHOST in case of direct connection via HTTP '
+                'or RFC',
+                'and use the option --mshost or the variable SAP_MSHOST in case of RFC or a load balancer'
+            )))
 
     if not args.client:
         report_args_error_and_exit(
-            arg_parser,
-            ': '.join(('No SAP Client provided',
-                       'use the option --client or the environment variable SAP_CLIENT')))
+            arg_parser, ': '.join((
+                'No SAP Client provided',
+                'use the option --client or the environment variable SAP_CLIENT'
+            )))
 
-    if not args.user:
-        args.user = input('Login:')
+    if not (args.snc_qop or args.snc_myname or args.snc_partnername):
+        if not args.user:
+            args.user = input('Login:')
 
-    if not args.password:
-        args.password = getpass.getpass()
+        if not args.password:
+            args.password = getpass.getpass()
 
     return args
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,6 @@
 coverage>=5.4
 pylint>=2.6.0
 flake8>=3.8.4
+mypy>=0.930
+types-PyYAML>=6.0.1
+types-requests>=2.26.2

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+disable_error_code = no-redef, import

--- a/sap/adt/acoverage_statements.py
+++ b/sap/adt/acoverage_statements.py
@@ -1,7 +1,7 @@
 """ABAP Unit Test Coverage framework code highlighting wrappers"""
 import xml
 from typing import NamedTuple, List
-from xml.sax import ContentHandler
+from xml.sax.handler import ContentHandler
 
 from sap import get_logger
 from sap.adt.annotations import OrderedClassMembers, xml_attribute, xml_element

--- a/sap/adt/cts.py
+++ b/sap/adt/cts.py
@@ -5,7 +5,7 @@ import xml.sax
 from xml.sax.handler import ContentHandler
 from xml.sax.saxutils import escape
 
-from typing import NamedTuple, Any, List
+from typing import NamedTuple, Any, List, Tuple
 
 from sap import get_logger
 from sap.errors import SAPCliError
@@ -169,7 +169,7 @@ class AbstractWorkbenchRequest:
 
         return f'cts/transportrequests/{self._number}'
 
-    def _create_request(self) -> (str, str):
+    def _create_request(self) -> Tuple[str, str]:
         """Returns a tuple (CTS URI request, XML content)"""
 
         raise NotImplementedError

--- a/sap/cli/__init__.py
+++ b/sap/cli/__init__.py
@@ -71,18 +71,16 @@ class CommandsCache:
             ]
 
         if CommandsCache.rfc is None:
-            if rfc.rfc_is_available():
-                import sap.cli.startrfc
-                import sap.cli.strust
-                import sap.cli.user
+            import sap.cli.startrfc
+            import sap.cli.strust
+            import sap.cli.user
 
-                CommandsCache.rfc = [
+            CommandsCache.rfc = [
                     (rfc_connection_from_args, sap.cli.startrfc.CommandGroup()),
                     (rfc_connection_from_args, sap.cli.strust.CommandGroup()),
                     (rfc_connection_from_args, sap.cli.user.CommandGroup())
-                ]
-            else:
-                CommandsCache.rfc = []
+            ]
+
 
         if CommandsCache.odata is None:
             CommandsCache.odata = [
@@ -108,7 +106,17 @@ def rfc_connection_from_args(args):
     """Returns RFC connection constructed from the passed args (Namespace)
     """
 
-    return rfc.connect(args.ashost, args.sysnr, args.client, args.user, args.password)
+    rfc_args_name = [
+        "ashost", "sysnr", "client", "user", "password", "mshost", "msserv",
+        "sysid", "group", "snc_qop", "snc_myname", "snc_partnername", "snc_lib"
+    ]
+
+    rfc_args = {
+        name if name != "password" else "passwd": getattr(args, name)
+        for name in rfc_args_name if name in args and getattr(args, name)
+    }
+
+    return rfc.connect(**rfc_args)
 
 
 def gcts_connection_from_args(args):

--- a/sap/config.py
+++ b/sap/config.py
@@ -1,9 +1,10 @@
 """Configuration"""
 
 import os
+from typing import Any
 
 
-def config_get(option: str, default: str = None) -> str:
+def config_get(option: str, default: Any = None) -> Any:
     """Returns configuration values"""
 
     config = {'http_timeout': float(os.environ.get('SAPCLI_HTTP_TIMEOUT', 900))}

--- a/sap/rest/connection.py
+++ b/sap/rest/connection.py
@@ -37,10 +37,12 @@ def setup_keepalive():
 
     # Special thanks to: https://www.finbourne.com/blog/the-mysterious-hanging-client-tcp-keep-alives
     # This may cause problems in Windows!
-    HTTPConnection.default_socket_options = HTTPConnection.default_socket_options + [
-        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-        (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
-    ]
+    if "TCP_KEEPIDLE" in dir(socket):
+        # pylint: disable=no-member
+        HTTPConnection.default_socket_options = HTTPConnection.default_socket_options + [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+            (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
+        ]
 
 
 # pylint: disable=too-many-instance-attributes

--- a/sap/rfc/core.py
+++ b/sap/rfc/core.py
@@ -52,16 +52,13 @@ def rfc_is_available():
     return SAPRFC_MODULE is not None
 
 
-def connect(host, sysnr, client, user, password):
-    """ADT Connection for HTTP communication built on top Python requests.
+def connect(**kwargs):
+    """SAP RFC Connection.
     """
 
     if not rfc_is_available():
-        raise sap.errors.SAPCliError('RFC functionality is not available(enabled)')
+        raise sap.errors.SAPCliError(
+            'RFC functionality is not available(enabled)')
 
-    mod_log().info('Connecting to HOST=%s SYSNR=%s CLIENT=%s as %s', host, sysnr, client, user)
-    return SAPRFC_MODULE.Connection(ashost=host,
-                                    sysnr=sysnr,
-                                    client=client,
-                                    user=user,
-                                    passwd=password)
+    mod_log().info('Connecting via SAP rfc with params %s', kwargs)
+    return SAPRFC_MODULE.Connection(**kwargs)

--- a/sap/rfc/core.py
+++ b/sap/rfc/core.py
@@ -1,14 +1,14 @@
 """Base RFC functionality"""
 
 
-from typing import Dict
+from typing import Any, Dict
 
 import sap
 import sap.errors
 
 
-RFCParams = Dict[str, str]
-RFCResponse = Dict[str, str]
+RFCParams = Dict[str, Any]
+RFCResponse = Dict[str, Any]
 
 
 SAPRFC_MODULE = None

--- a/sap/rfc/user.py
+++ b/sap/rfc/user.py
@@ -2,7 +2,7 @@
 
 import datetime
 
-from typing import Dict, Union, List
+from typing import Dict, Optional, Union, List
 
 from sap.rfc.core import RFCParams
 from sap.rfc.bapi import (
@@ -179,7 +179,7 @@ class UserBuilder:
     def build_rfc_params(self) -> RFCParams:
         """Creates RFC parameters for Creating users"""
 
-        params = {}
+        params: RFCParams = {}
 
         self._rfc_params_add_username(params)
 
@@ -205,7 +205,7 @@ class UserBuilder:
     def build_change_rfc_params(self) -> RFCParams:
         """Create RFC parameters fro Updating user"""
 
-        params = {}
+        params: RFCParams = {}
         self._rfc_params_add_username(params)
 
         if self._password:
@@ -228,7 +228,7 @@ class UserRoleAssignmentBuilder:
         self._roles = role_names
         return self
 
-    def build_rfc_params(self) -> RFCParams:
+    def build_rfc_params(self) -> Optional[RFCParams]:
         """Creates RFC parameters"""
 
         if not self._roles:
@@ -263,7 +263,7 @@ class UserProfileAssignmentBuilder:
         self._profiles = profile_names
         return self
 
-    def build_rfc_params(self) -> RFCParams:
+    def build_rfc_params(self) -> Optional[RFCParams]:
         """Creates RFC parameters"""
 
         if not self._profiles:
@@ -303,13 +303,13 @@ class UserManager:
                                       'BAPI_USER_GET_DETAIL',
                                       {'USERNAME': username})
 
-    def create_user(self, connection, user_builder: UserBuilder) -> UserId:
+    def create_user(self, connection, user_builder: UserBuilder) -> BAPIReturn:
         """Creates a new user for the given user data"""
 
         rfc_ret = self._call_bapi_method(connection, 'BAPI_USER_CREATE1', user_builder.build_rfc_params())
         return BAPIReturn(rfc_ret['RETURN'])
 
-    def change_user(self, connection, user_builder: UserBuilder) -> UserId:
+    def change_user(self, connection, user_builder: UserBuilder) -> BAPIReturn:
         """Updates user with the given user data"""
 
         rfc_ret = self._call_bapi_method(connection, 'BAPI_USER_CHANGE', user_builder.build_change_rfc_params())

--- a/test/unit/test_bin_sapcli.py
+++ b/test/unit/test_bin_sapcli.py
@@ -18,10 +18,10 @@ sapcli = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(sapcli)
 sys.modules['sapcli'] = sapcli
 
-
 ALL_PARAMETERS = [
-    'sapcli', '--ashost', 'fixtures', '--sysnr', '69', '--client', '975', '--port', '3579',
-    '--no-ssl', '--skip-ssl-validation', '--user', 'fantomas', '--password', 'Down1oad'
+    'sapcli', '--ashost', 'fixtures', '--sysnr', '69', '--client', '975',
+    '--port', '3579', '--no-ssl', '--skip-ssl-validation', '--user',
+    'fantomas', '--password', 'Down1oad', '--snc_lib', 'somelib.dylib'
 ]
 
 
@@ -38,9 +38,25 @@ class TestParseCommandLine(unittest.TestCase):
         args = sapcli.parse_command_line(params)
 
         self.assertEqual(
-            vars(args),
-            {'ashost':'fixtures', 'sysnr':'69', 'client':'975', 'ssl':False, 'port':3579,
-             'user':'fantomas', 'password':'Down1oad', 'verify':False, 'verbose_count':0})
+            vars(args), {
+                'ashost': 'fixtures',
+                'sysnr': '69',
+                'client': '975',
+                'ssl': False,
+                'port': 3579,
+                'user': 'fantomas',
+                'password': 'Down1oad',
+                'verify': False,
+                'verbose_count': 0,
+                'group': None,
+                'mshost': None,
+                'msserv': None,
+                'snc_myname': None,
+                'snc_partnername': None,
+                'snc_qop': None,
+                'snc_lib': "somelib.dylib",
+                'sysid': None,
+            })
 
     def test_args_no_ashost(self):
         test_params = ALL_PARAMETERS.copy()

--- a/test/unit/test_sap_cli_object.py
+++ b/test/unit/test_sap_cli_object.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 
 import sap.cli.object
 
-from mock import Connection, Response, patch_get_print_console_with_buffer
+from mock import patch_get_print_console_with_buffer
 from fixtures_adt import DummyADTObject, LOCK_RESPONSE_OK, EMPTY_RESPONSE_OK, OBJECT_METADATA
 from fixtures_adt_wb import MessageBuilder
 
@@ -120,7 +120,7 @@ class TestCommandGroupObjectTemplate(unittest.TestCase):
 
     @property
     def group(self):
-        return sefl.__class__.group
+        return self.__class__.group
 
     def setUp(self):
         self.group._init_mocks()
@@ -429,7 +429,7 @@ class TestCommandGroupObjectMaster(unittest.TestCase):
 
     @property
     def group(self):
-        return sefl.__class__.group
+        return self.__class__.group
 
     def setUp(self):
         self.group._init_mocks()

--- a/test/unit/test_sap_rfc.py
+++ b/test/unit/test_sap_rfc.py
@@ -34,16 +34,29 @@ class TestRFCCore(unittest.TestCase):
             with patch('importlib.__import__') as fake_import:
                 fake_import.side_effect = ImportError('mock error')
 
-                sap.rfc.core.connect('ashost', '00', '100', 'anzeiger', 'display')
+                sap.rfc.core.connect(ashost='ashost',
+                                     sysnr='00',
+                                     client='100',
+                                     user='anzeiger',
+                                     password='display')
 
-        self.assertEqual(str(caught.exception), 'RFC functionality is not available(enabled)')
+        self.assertEqual(str(caught.exception),
+                         'RFC functionality is not available(enabled)')
 
     def test_connect_available(self):
         fake_pyrfc = MagicMock()
 
         with patch.dict('sys.modules', pyrfc=fake_pyrfc):
-            conn = sap.rfc.core.connect('ashost', '00', '100', 'anzeiger', 'display')
+            conn = sap.rfc.core.connect(ashost='ashost',
+                                        sysnr='00',
+                                        client='100',
+                                        user='anzeiger',
+                                        passwd='display')
 
         self.assertIsNotNone(conn)
         self.assertEqual(conn, fake_pyrfc.Connection.return_value)
-        fake_pyrfc.Connection.assert_called_once_with(ashost='ashost', sysnr='00', client='100', user='anzeiger', passwd='display')
+        fake_pyrfc.Connection.assert_called_once_with(ashost='ashost',
+                                                      sysnr='00',
+                                                      client='100',
+                                                      user='anzeiger',
+                                                      passwd='display')


### PR DESCRIPTION
This PR should be considered after #56 

This adds all the `pyrfc.Connect` parameters to the cli.
It also changes that the cli always display actions depending on pyrfc (like getting user info `sapcli user <username>`). Beforehand they were hidden if pyrfc was not installed. Now they always show. I feel that this is better because this will lead to better error messages. In detail, if `pyrfc` is not installed beforehand, a call to `sapcli user` gave the same result as having a typo, whereas not it states that `pyrfc` could not be loaded.