### PR TITLE
strust: Commands for listing and dumping certificates

### DIFF
--- a/doc/commands/strust.md
+++ b/doc/commands/strust.md
@@ -1,0 +1,51 @@
+# strust
+
+This command allows basic operations on SAP certificates store. It allows to
+upload or list X.509 certificates, which are used for SSL peer verification
+of remote servers
+
+1. [putcertificate](#putcertificate)
+2. [listcertificates](#listcertificates)
+2. [dumpcertificates](#dumpcertificates)
+
+## putcertificate
+
+Uploads certificate to the SAP system from local filesystem. File shall be encoded
+as bas64 X.509 certificate
+
+```bash
+sapcli strust putcertificate --store client_standard ./cert.pem"
+```
+
+## listcertificates
+
+Lists (briefly) all certificates from specified identities and stores.
+
+```bash
+sapcli strust listcertificates --store client_standard"
+```
+
+## dumpcertificates
+
+Dumps all certificates from specified identities and stores in PEM format.
+
+```bash
+sapcli strust dumpcertificates --store client_standard"
+```
+
+And this is how to process pem output in shell (`csplit` and `openssl` commands
+have to be available). Each certificate will be stored as single file:
+
+```bash
+# output dump to a file
+sapcli strust listcertificate --store client_standard > certs.pem
+
+# split into files - one file per one certificate
+csplit -s -z -f cert- certs.pem '/-----BEGIN CERTIFICATE-----/' '{*}'
+
+# show issuer and expiration date for each certificatte
+for $f in cert-* do; cat $f | openssl x509 -issuer -enddate -noout; done 
+```
+were:
+* `-s` skips printing output of file sizes
+* `-z` does not create empty files

--- a/sap/rfc/strust.py
+++ b/sap/rfc/strust.py
@@ -138,6 +138,15 @@ class SSLCertStorage:
 
         return stat['ET_CERTIFICATELIST']
 
+    def parse_certificate(self, xcert):
+        """Parse certificate from binary X.509 format to python structure"""
+        cert = self._connection.call(
+            'SSFR_PARSE_CERTIFICATE',
+            IV_CERTIFICATE=xcert
+        )
+
+        return cert
+
 
 def notify_icm_changed_pse(connection):
     """Informs ICM about changed PSE"""

--- a/test/unit/test_sap_rfc_strust_ssl_cert_storage.py
+++ b/test/unit/test_sap_rfc_strust_ssl_cert_storage.py
@@ -195,6 +195,19 @@ class TestSSLCertStorage(unittest.TestCase):
                                                         'PSE_APPLIC': 'TEST'},
                                     IV_CERTIFICATE=u'plain old data')])
 
+    def test_parse_certificate(self):
+        mock_connection = Mock()
+        mock_connection.call.return_value = {'EV_SUBJECT': 'cert subject'}
+
+        ssl_storage = SSLCertStorage(mock_connection, 'PUTOK', 'TEST')
+
+        result = ssl_storage.parse_certificate(b'binary cert data')
+
+        self.assertEqual(mock_connection.call.call_args_list,
+                         [mock.call('SSFR_PARSE_CERTIFICATE',
+                                    IV_CERTIFICATE=b'binary cert data')])
+
+        self.assertEqual(result, {'EV_SUBJECT': 'cert subject'})
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Adding two new commands for listing and dumping of SSL certificates.
* Adding also missing documentation for strust that was missing.