### PR TITLE
startrfc: add the posibility to backup response

### DIFF
--- a/doc/commands/startrfc.md
+++ b/doc/commands/startrfc.md
@@ -31,6 +31,19 @@ sapcli startrfc --output={human,json} RFC_FUNCTION_MODULE {JSON_PARAMETERS,-} \
   Function Module as a command line parameter. The value path is used to open
   a file and its contents will be used as value of the RFC param.
 
+* -c | --result-checker:  enables analysis of returned response
+  * _raw_ the default value which does not do any analysis, just prints out the
+     formatted response
+  * _bapi_ stops printing out the retrieved response and instead tries to get
+    the member *RETURN* from the response, expects the value is a table of the
+    ABAP type *bapiret2* and prints out messages - if error message is
+    found, only the error message is printed out and the process exists with
+    non-0 exit code.
+
+* -R | --response-file:  holds a file path where the complete response of the
+  executed function module will be stored regardles of the result-checker's
+  verdict. The format of the file is taken from the parameter '--output'.
+
 ## Example: human readable output of STFC\_CONNECTION
 
 Run the function module checking connection to ABAP Trial system deployed in

--- a/test/unit/fixtures_rfc.py
+++ b/test/unit/fixtures_rfc.py
@@ -1,0 +1,50 @@
+BAPIRET2_INFO = {
+    'FIELD': '',
+    'ID': 'CICD_GCTS_TR',
+    'LOG_MSG_NO': '000000',
+    'LOG_NO': '',
+    'MESSAGE': 'Everything is OK',
+    'MESSAGE_V1': '',
+    'MESSAGE_V2': '',
+    'MESSAGE_V3': '',
+    'MESSAGE_V4': '',
+    'NUMBER': '007',
+    'PARAMETER': '',
+    'ROW': 0,
+    'SYSTEM': '',
+    'TYPE': 'I'
+}
+
+BAPIRET2_WARNING = {
+    'FIELD': '',
+    'ID': 'CICD_GCTS_TR',
+    'LOG_MSG_NO': '000000',
+    'LOG_NO': '',
+    'MESSAGE': 'List of ABAP repository objects (piece list) is empty',
+    'MESSAGE_V1': '',
+    'MESSAGE_V2': '',
+    'MESSAGE_V3': '',
+    'MESSAGE_V4': '',
+    'NUMBER': '045',
+    'PARAMETER': '',
+    'ROW': 0,
+    'SYSTEM': '',
+    'TYPE': 'W'
+}
+
+BAPIRET2_ERROR = {
+    'FIELD': '',
+    'ID': 'CICD_GCTS_TR',
+    'LOG_MSG_NO': '000000',
+    'LOG_NO': '',
+    'MESSAGE': 'List of ABAP repository objects (piece list) is empty',
+    'MESSAGE_V1': '',
+    'MESSAGE_V2': '',
+    'MESSAGE_V3': '',
+    'MESSAGE_V4': '',
+    'NUMBER': '045',
+    'PARAMETER': '',
+    'ROW': 0,
+    'SYSTEM': '',
+    'TYPE': 'E'
+}

--- a/test/unit/mock.py
+++ b/test/unit/mock.py
@@ -452,3 +452,17 @@ class TestRFCLibError(Exception):
 
 mod_exception = types.SimpleNamespace(RFCLibError=TestRFCLibError)
 mod_pyrfc = types.SimpleNamespace(_exception=mod_exception)
+
+
+class RetainedStringIO(StringIO):
+    """Because the parent StringIO raises an error if you call
+       getvalue() after the call to close().
+    """
+
+    def __init__(self):
+        self.finalvalue = None
+        super().__init__()
+
+    def close(self):
+        self.finalvalue = self.getvalue()
+        super().close()


### PR DESCRIPTION
We do want to analyze BAPI response, print nice messages and exit with
non-0 in the case of error but we also need to save the response for
further processing if there is no error.