### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-alpine
+
+RUN pip3 install requests
+
+COPY . /opt/sapcli
+
+RUN cd /opt/sapcli &&\
+	python3 -m pip install -r requirements.txt &&\
+	chmod +x /opt/sapcli/sapcli &&\
+	echo '#!/bin/sh' > /usr/bin/sapcli &&\
+	echo 'python3  /opt/sapcli/sapcli "$@"' >> /usr/bin/sapcli &&\
+	chmod +x /usr/bin/sapcli
+
+WORKDIR /var/tmp
+
+ENTRYPOINT ["sapcli"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,11 @@ COPY . /opt/sapcli
 
 RUN cd /opt/sapcli &&\
 	python3 -m pip install -r requirements.txt &&\
-	chmod +x /opt/sapcli/sapcli &&\
-	echo '#!/bin/sh' > /usr/bin/sapcli &&\
-	echo 'python3  /opt/sapcli/sapcli "$@"' >> /usr/bin/sapcli &&\
-	chmod +x /usr/bin/sapcli
+	dos2unix /opt/sapcli/bin/sapcli &&\
+	chmod +x /opt/sapcli/bin/sapcli
+
+ENV PATH="/opt/sapcli/bin:${PATH}"
+ENV PYTHONPATH="/opt/sapcli:${PYTHONPATH}"
 
 WORKDIR /var/tmp
 


### PR DESCRIPTION
This allows to run a sapcli command through docker by using `docker run sapcli [COMMAND]`.

Alternatively, you can open a shell in the container and run multiple commands by using, for example, `docker run -it --entrypoint /bin/sh sapcli`, which can be useful for automation. sapcli is globally available as an executable.