### PR TITLE
Fixed mixup of system-errors between test suites

### DIFF
--- a/sap/adt/aunit.py
+++ b/sap/adt/aunit.py
@@ -362,9 +362,9 @@ class AUnitResponseHandler(ContentHandler):
         mod_log().debug('XML: %s: CLOSING', name)
         if name == 'program':
             self._program = None
-        elif name == 'testclas':
+        elif name == 'testClas':
             self._test_class = None
-        elif name == 'testmethod':
+        elif name == 'testMethod':
             self._test_method = None
         elif name == 'title':
             self._alert_title = self._alert_title_part

--- a/sap/cli/aunit.py
+++ b/sap/cli/aunit.py
@@ -76,6 +76,8 @@ def print_aunit_human(run_results, console):
         for test_class in program.test_classes:
             console.printout(f'  {test_class.name}')
 
+            errors += print_aunit_human_alerts(console, test_class.alerts)
+
             for test_method in test_class.test_methods:
                 result = None
                 if any((alert.is_error for alert in test_method.alerts)):
@@ -301,6 +303,13 @@ def print_aunit_junit4(run_results, args, console):
                                         name=test_class.name,
                                         package=program.name,
                                         tests=str(len(test_class.test_methods))):
+
+                    if test_class.alerts:
+                        critical += print_junit4_testcase(xml_writer,
+                                                          test_class.name,
+                                                          test_class.name,
+                                                          test_class.alerts)
+
                     if not test_class.test_methods:
                         continue
 

--- a/test/unit/fixtures_adt_aunit.py
+++ b/test/unit/fixtures_adt_aunit.py
@@ -139,6 +139,37 @@ GLOBAL_TEST_CLASS_AUNIT_RESULTS_XML = '''<?xml version="1.0" encoding="UTF-8"?>
 </aunit:runResult>
 '''
 
+TEST_CLASS_WITH_SYS_ERROR_FOLLOWED_BY_GREEN_TEST_CLASS_AUNIT_RESULTS_XML = '''<?xml version="1.0" encoding="UTF-8"?>
+<aunit:runResult xmlns:aunit="http://www.sap.com/adt/aunit">
+  <program xmlns:adtcore="http://www.sap.com/adt/core" adtcore:uri="/sap/bc/adt/oo/classes/zcl_test_class_green" adtcore:type="CLAS/OC" adtcore:name="ZCL_TEST_CLASS_GREEN" uriType="semantic" durationCategory="short" riskLevel="harmless">
+    <testClasses>
+      <testClass adtcore:uri="/sap/bc/adt/oo/classes/zcl_test_class_green/source/main" adtcore:type="CLAS/OC" adtcore:name="ZCL_TEST_CLASS_GREEN" adtcore:parentUri="/sap/bc/adt/oo/classes/zcl_test_class_green" uriType="semantic" navigationUri="/sap/bc/adt/oo/classes/zcl_test_class_green/source/main" durationCategory="short" riskLevel="harmless">
+        <testMethods>
+          <testMethod adtcore:uri="/sap/bc/adt/oo/classes/zcl_test_class_green/source/main#type=CLAS%2FOM;name=DO_THE_TEST" adtcore:type="CLAS/OM/private" adtcore:name="DO_THE_TEST" executionTime="0" uriType="semantic" navigationUri="/sap/bc/adt/oo/classes/zcl_test_class_green/source/main#type=CLAS%2FOM;name=DO_THE_TEST" unit="s"/>
+        </testMethods>
+      </testClass>    
+    </testClasses>
+  </program>
+  <program xmlns:adtcore="http://www.sap.com/adt/core" adtcore:uri="/sap/bc/adt/oo/classes/zcl_test_class" adtcore:type="CLAS/OC" adtcore:name="ZCL_TEST_CLASS" uriType="semantic" durationCategory="short" riskLevel="harmless">
+    <testClasses>
+      <testClass adtcore:uri="/sap/bc/adt/oo/classes/zcl_test_class/source/main" adtcore:type="CLAS/OC" adtcore:name="ZCL_TEST_CLASS" adtcore:parentUri="/sap/bc/adt/oo/classes/zcl_test_class" uriType="semantic" navigationUri="/sap/bc/adt/oo/classes/zcl_test_class/source/main" durationCategory="short" riskLevel="harmless">
+        <alerts>
+          <alert kind="failedAssertion" severity="critical">
+            <title>The global test class [ZCL_TEST_CLASS] is not abstract</title>
+            <details>
+              <detail text="Some detail text"/>
+            </details>
+            <stack>
+                <stackEntry adtcore:uri="/sap/bc/adt/oo/classes/zcl_test_class/source/main#start=1,10" adtcore:type="CLAS/OC" adtcore:name="ZCL_TEST_CLASS" adtcore:description="Include: &lt;ZCL_TEST_CLASS=======CM010&gt; Line: &lt;1&gt;"/>
+            </stack>            
+          </alert>
+        </alerts>
+      </testClass>
+    </testClasses>
+  </program>  
+</aunit:runResult>
+'''
+
 AUNIT_NO_EXECUTION_TIME_RESULTS_XML = '''<?xml version="1.0" encoding="UTF-8"?>
 <aunit:runResult xmlns:aunit="http://www.sap.com/adt/aunit">
   <program xmlns:adtcore="http://www.sap.com/adt/core" adtcore:uri="/sap/bc/adt/oo/classes/zcl_test_class" adtcore:type="CLAS/OC" adtcore:name="ZCL_TEST_CLASS" uriType="semantic" durationCategory="short" riskLevel="harmless">


### PR DESCRIPTION
Corrected bug in parser that in some combinations a system error was associated with the previous test class. 

In our case this was caused by wrongly using the class `CL_CDS_TEST_ENVIRONMENT` in a test class (This causes the AUNIT runner to not execute any tests in this class.). But the error of the `CL_CDS_TEST_ENVIRONMENT` was displayed in the previous tested class instead of the class it originated from. That part is covered by a new unit test. 

Along with that I passed on the collected alerts for test classes while creating the junit4 xml. 