### PR TITLE
gcts: add support of URL in PACKAGE argument

### DIFF
--- a/doc/commands/gcts.md
+++ b/doc/commands/gcts.md
@@ -49,6 +49,9 @@ Checkout branch
 sapcli gcts checkout PACKAGE BRANCH
 ```
 
+**Parameters:**:
+- `PACKAGE`: Repository name or URL
+
 ## log
 
 Print out repository history log
@@ -57,6 +60,9 @@ Print out repository history log
 sapcli gcts log PACKAGE
 ```
 
+**Parameters:**:
+- `PACKAGE`: Repository name or URL
+
 ## pull
 
 Pulls the repository on the system
@@ -64,6 +70,9 @@ Pulls the repository on the system
 ```bash
 sapcli gcts pull PACKAGE
 ```
+
+**Parameters:**:
+- `PACKAGE`: Repository name or URL
 
 ## commit
 
@@ -74,7 +83,7 @@ sapcli gcts commit PACKAGE CORRNR [-m|--message MESSAGE] [--description DESCRIPT
 ```
 
 **Parameters:**:
-- `PACKAGE`: Repository name
+- `PACKAGE`: Repository name or URL
 - `CORRNR`: Transport number (e.g. from *sapcli cts list transport*)
 - `--message MESSAGE`: Short commit messsage
 - `--description DESCRIPTION`: Commit message body
@@ -87,6 +96,9 @@ Removes the repository not the package
 sapcli gcts delete PACKAGE
 ```
 
+**Parameters:**:
+- `PACKAGE`: Repository name or URL
+
 ## config
 
 Configure the given repository
@@ -96,6 +108,7 @@ sapcli gcts config [-l|--list] PACKAGE
 ```
 
 **Parameters:**:
+- `PACKAGE`: Repository name or URL
 - `--list`: Lists all configuration options for the specified repository
 
 ## user get-credentials

--- a/sap/rest/gcts/simple.py
+++ b/sap/rest/gcts/simple.py
@@ -90,10 +90,13 @@ def pull(connection, name=None, repo=None):
     return repo.pull()
 
 
-def delete(connection, name):
+def delete(connection, name=None, repo=None):
     """Deletes the given repository on the give system"""
 
-    return Repository(connection, name).delete()
+    if repo is None:
+        repo = Repository(connection, name)
+
+    return repo.delete()
 
 
 def get_user_credentials(connection):

--- a/test/unit/test_sap_rest_gcts.py
+++ b/test/unit/test_sap_rest_gcts.py
@@ -702,15 +702,22 @@ class TestgCTSSimpleAPI(GCTSTestSetUp, unittest.TestCase):
         self.assertEqual(response, 'probe')
 
     @patch('sap.rest.gcts.simple.Repository')
-    def test_simple_delete_ok(self, fake_repository):
+    def test_simple_delete_name(self, fake_repository):
         fake_instance = Mock()
         fake_repository.return_value = fake_instance
         fake_instance.delete = Mock()
         fake_instance.delete.return_value = 'probe'
 
-        response = sap.rest.gcts.simple.delete(self.conn, self.repo_name)
+        response = sap.rest.gcts.simple.delete(self.conn, name=self.repo_name)
         fake_repository.assert_called_once_with(self.conn, self.repo_name)
         fake_instance.delete.assert_called_once_with()
+        self.assertEqual(response, 'probe')
+
+    def test_simple_delete_repo(self):
+        fake_instance = Mock()
+        fake_instance.delete.return_value = 'probe'
+
+        response = sap.rest.gcts.simple.delete(None, repo=fake_instance)
         self.assertEqual(response, 'probe')
 
     @patch('sap.rest.gcts.simple.Repository')


### PR DESCRIPTION
The PACKAGE argument still supports the repository name, but if the argument starts with 'http://' or 'https://' it is meant as repository URL.

If the command is called with URL, it will fail either when there are no repositories with this URL or when there are multiple repositories with the same URL.