### PR TITLE
Add function for fetching X.509 Base64 certificate

### DIFF
--- a/doc/commands/strust.md
+++ b/doc/commands/strust.md
@@ -107,11 +107,19 @@ sapcli strust upload [-i|--identity IDENTITY] [-s|--storage STORAGE] [--pse-pass
 
 ## putcertificate
 
-Uploads certificate to the SAP system from local filesystem. File shall be encoded
-as bas64 X.509 certificate
+Uploads certificate to the SAP system. The certificate can be passed from local filesystem or read from input stream.   
+Both the file and data in input stream shall be encoded as Base64 X.509 certificate.
 
 ```bash
 sapcli strust putcertificate --store client_standard ./cert.pem"
+```
+
+## getowncert
+
+Prints out X.509 Base64 certificate.
+
+```bash
+sapcli strust getowncert --store client_standard
 ```
 
 ## listcertificates

--- a/sap/cli/core.py
+++ b/sap/cli/core.py
@@ -245,3 +245,22 @@ def printerr(*objects, sep=' ', end='\n'):
     """A shortcut for get_console().printerr()"""
 
     get_console().printerr(*objects, sep=sep, end=end)
+
+
+_SAPCLI_STDIN_ = None
+
+
+def get_stdin():
+    """Returns current standard user input"""
+
+    return _SAPCLI_STDIN_
+
+
+def set_stdin(reader):
+    """Set standard user input"""
+
+    # pylint: disable=global-statement
+    global _SAPCLI_STDIN_
+    oldvalue = _SAPCLI_STDIN_
+    _SAPCLI_STDIN_ = reader
+    return oldvalue

--- a/sap/cli/strust.py
+++ b/sap/cli/strust.py
@@ -28,7 +28,10 @@ from sap.rfc.strust import (
     iter_storage_certificates,
     list_identities
 )
-from sap.cli.core import printout
+from sap.cli.core import (
+    printout,
+    get_stdin
+)
 from sap.cli.helpers import TableWriter
 
 
@@ -218,7 +221,7 @@ def upload(connection, args):
 
 
 @CommandGroup.argument('paths', type=str, nargs='+',
-                       help='a file path containing X.509 Base64 certificate')
+                       help='a file path containing X.509 Base64 certificate or X.509 Base64 certificate')
 @CommandGroup.argument('-l', '--algorithm', type=str, help='R,S,G,H,X - or other if you need, of PSE file', default='R')
 @CommandGroup.argument('-k', '--key-length', type=int, default=2048, help='Of PSE file')
 @CommandGroup.argument('-d', '--dn', type=str, help='Distinguished Name of PSE file', default=None)
@@ -249,13 +252,21 @@ def putcertificate(connection, args):
 
         logging.debug('SSL Storage is OK: %s', ssl_storage)
 
-    for file_path in args.paths:
-        logging.info('Processing the file: %s', file_path)
-        with open(file_path, 'rb') as cert_file:
-            cert_contents = cert_file.read()
-            for ssl_storage in ssl_storages:
-                logging.info('Adding the file: %s to %s', file_path, ssl_storage)
-                logging.info(ssl_storage.put_certificate(cert_contents))
+    if args.paths[0] == '-':
+        certificates = read_certificates()
+
+        for ssl_storage in ssl_storages:
+            for cert_content in certificates:
+                logging.info('Adding the certificate: %s to %s', cert_content.encode(), ssl_storage)
+                logging.info(ssl_storage.put_certificate(cert_content.encode()))
+    else:
+        for file_path in args.paths:
+            logging.info('Processing the file: %s', file_path)
+            with open(file_path, 'rb') as cert_file:
+                cert_contents = cert_file.read()
+                for ssl_storage in ssl_storages:
+                    logging.info('Adding the file: %s to %s', file_path, ssl_storage)
+                    logging.info(ssl_storage.put_certificate(cert_contents))
 
     logging.info('Notifying ICM ... ')
     notify_icm_changed_pse(connection)
@@ -367,3 +378,21 @@ def ssl_storages_from_arguments(connection, args):
         ssl_storages.append(ssl_storage)
 
     return ssl_storages
+
+
+def read_certificates():
+    """Helper function to build list of certificates from stdin"""
+
+    cert_input = ""
+
+    if get_stdin() is None:
+        cert_input = sys.stdin.read()
+    else:
+        cert_input = get_stdin().read()
+
+    certificates = []
+
+    if cert_input:
+        certificates = cert_input.split(", ")
+
+    return certificates

--- a/sap/cli/strust.py
+++ b/sap/cli/strust.py
@@ -267,6 +267,24 @@ def putcertificate(connection, args):
             logging.info('* %s', cert['EV_SUBJECT'])
 
 
+@CommandGroup.argument('-s', '--storage', default=None, help='Mutually exclusive with the option -i',
+                       choices=[CLIENT_ANONYMOUS, CLIENT_STANDART, CLIENT_STANDARD, SERVER_STANDARD, ])
+@CommandGroup.argument('-i', '--identity', default=None, help='Mutually exclusive with the option -s',)
+@CommandGroup.command()
+def getowncert(connection, args):
+    """Prints out X.509 Base64 certificate.
+    """
+
+    ssl_storage = _get_ssl_storage_from_args(connection, args)
+
+    cert = ssl_storage.get_own_certificate()
+    cert_x509 = base64.b64encode(cert).decode('ascii')
+
+    printout('-----BEGIN CERTIFICATE-----')
+    printout(cert_x509)
+    printout('-----END CERTIFICATE-----')
+
+
 @CommandGroup.argument('-s', '--storage', action='append', default=[],
                        choices=[CLIENT_ANONYMOUS, CLIENT_STANDART, CLIENT_STANDARD, SERVER_STANDARD, ])
 @CommandGroup.argument('-i', '--identity', action='append', default=[])

--- a/sap/rfc/strust.py
+++ b/sap/rfc/strust.py
@@ -230,6 +230,20 @@ class SSLCertStorage:
             f'Failed to put the CERT to the {str(self)}: {ret[0]["MESSAGE"]}'
         )
 
+    def get_own_certificate(self) -> bytes:
+        """Returns X.509 Base64 certificate"""
+
+        own_cert_resp = self._connection.call(
+            'SSFR_GET_OWNCERTIFICATE',
+            IS_STRUST_IDENTITY=self.identity,
+        )
+
+        bapiret = BAPIReturn(own_cert_resp['ET_BAPIRET2'])
+        if bapiret.is_error:
+            raise BAPIError(bapiret, own_cert_resp)
+
+        return own_cert_resp['EV_CERTIFICATE']
+
     def get_certificates(self):
         """Returns the certificate list"""
 

--- a/test/unit/test_sap_rfc_strust.py
+++ b/test/unit/test_sap_rfc_strust.py
@@ -375,6 +375,26 @@ class TestSSLCertStorage(unittest.TestCase):
 
         fake_put_identity_cert.assert_called_with(storage, pkc_response)
 
+    def test_get_own_certificate(self):
+        expected_own_cert = b'test_get_own_certificate'
+        self.connection.set_responses([{'EV_CERTIFICATE': expected_own_cert, 'ET_BAPIRET2': []}])
+
+        result = self.ssl_storage.get_own_certificate()
+
+        self.assertEqual(result, expected_own_cert)
+        self.assert_rfc_call('SSFR_GET_OWNCERTIFICATE', **self.expected_storage_identity)
+
+    def test_get_own_certificate_raises(self):
+        self.connection.set_responses([{'ET_BAPIRET2': [
+            {'TYPE': 'E', 'ID': 1, 'NUMBER': 1, 'MESSAGE': 'Unit Test Error'}
+        ]}])
+
+        with self.assertRaises(BAPIError) as cm:
+            self.ssl_storage.get_own_certificate()
+
+        self.assertEqual('Error(1|1): Unit Test Error', str(cm.exception))
+        self.assert_rfc_call('SSFR_GET_OWNCERTIFICATE', **self.expected_storage_identity)
+
 
 class TestListIdentities(unittest.TestCase):
 


### PR DESCRIPTION
Add function `getowncert` which fetches X.509 Base64 certificate.
Update function `putcertificate`, so that it support adding a new certificate directly using a new command line argument.