### PR TITLE
more robust activation procedure

### DIFF
--- a/sap/adt/objects.py
+++ b/sap/adt/objects.py
@@ -20,6 +20,8 @@ from sap.adt.annotations import (
 
 LOCK_ACCESS_MODE_MODIFY = 'MODIFY'
 
+ADT_OBJECT_VERSION_ACTIVE = 'active'
+
 
 def mimetype_to_version(mime):
     """Converts Object MIME type to a version string"""
@@ -360,6 +362,7 @@ class ADTObject(metaclass=OrderedClassMembers):
             - connection: ADT.Connection
             - name: string name
             - metadata: ADTCoreData
+            - active_status: string - status of object activation
         """
 
         self._connection = connection
@@ -1092,6 +1095,12 @@ class Class(OOADTObjectBase):
 
             return self._metadata.adt_type
 
+        @xml_attribute('adtcore:version')
+        def active(self):
+            """Version in regards of activation"""
+
+            return self._clas.active
+
         @xml_attribute('class:includeType')
         def include_type(self):
             """ADT Class include type"""
@@ -1121,6 +1130,10 @@ class Class(OOADTObjectBase):
                 lock_handle = self.lock()
 
             return self._clas.objtype.open_editor(self, lock_handle=lock_handle, corrnr=corrnr)
+
+        def fetch(self):
+            """Retrieve data from ADT"""
+            self._clas.fetch()
 
     def __init__(self, connection, name, package=None, metadata=None):
         super().__init__(connection, name, metadata)

--- a/sap/adt/wb.py
+++ b/sap/adt/wb.py
@@ -9,6 +9,7 @@ from sap.adt.marshalling import Marshal
 
 from sap import get_logger
 from sap.errors import SAPCliError
+from sap.adt.objects import ADT_OBJECT_VERSION_ACTIVE
 
 
 XMLNS_CHKL = XMLNamespace('chkl', 'http://www.sap.com/abapxml/checklis')
@@ -301,17 +302,20 @@ def try_activate(adt_object):
     if resp.text:
         Marshal.deserialize(resp.text, results)
 
+    # fetch object to refresh object attributes (e.g. current activation status)
+    adt_object.fetch()
+
     return (results, resp)
 
 
 def activate(adt_object):
     """Activates the given object and raises ActivationError
-    in the case where activation didn't generate the object.
+    in the case where activation didn't activate the object.
     """
 
     results, resp = try_activate(adt_object)
 
-    if not results.generated:
+    if adt_object.active != ADT_OBJECT_VERSION_ACTIVE:
         raise ActivationError(f'Could not activate: {resp.text}', resp, results)
 
     return results

--- a/sap/cli/wb.py
+++ b/sap/cli/wb.py
@@ -4,6 +4,7 @@ import sap.adt.wb
 
 from sap.errors import SAPCliError
 from sap.cli.core import printout
+from sap.adt.objects import ADT_OBJECT_VERSION_ACTIVE
 
 
 # pylint: disable=too-few-public-methods
@@ -95,7 +96,7 @@ class ObjectActivationWorker:
 
         error = False
 
-        if results.generated:
+        if obj.active == ADT_OBJECT_VERSION_ACTIVE:
             stats.active_objects.append(obj)
         else:
             stats.inactive_objects.append(obj)

--- a/test/unit/fixtures_adt.py
+++ b/test/unit/fixtures_adt.py
@@ -111,6 +111,18 @@ GET_DUMMY_OBJECT_ADT_XML = '''<?xml version="1.0" encoding="utf-8"?>
 </win:dummies>
 '''
 
+GET_DUMMY_OBJECT_INACTIVE_ADT_XML = '''<?xml version="1.0" encoding="utf-8"?>
+<win:dummies xmlns:class="http://www.sap.com/adt/awesome/success" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:responsible="DEVELOPER" adtcore:masterLanguage="EN" adtcore:masterSystem="NPL" adtcore:name="SOFTWARE_ENGINEER" adtcore:type="DUMMY/S" adtcore:changedAt="2019-03-07T20:22:01Z" adtcore:version="inactive" adtcore:createdAt="2019-02-02T00:00:00Z" adtcore:changedBy="DEVELOPER" adtcore:createdBy="DEVELOPER" adtcore:description="You cannot stop me!" adtcore:descriptionTextLimit="60" adtcore:language="CZ">
+  <adtcore:packageRef adtcore:name='UNIVERSE'/>
+</win:dummies>
+'''
+
+GET_DDL_ADT_XML = '''<?xml version="1.0" encoding="UTF-8"?>
+<ddl:ddlSource xmlns:ddl="http://www.sap.com/adt/ddic/ddlsources" ddl:source_origin="0" ddl:source_type="view" ddl:source_type_description="View Entity" ddl:source_origin_description="ABAP Development Tools" abapsource:sourceUri="source/main" abapsource:fixPointArithmetic="false" abapsource:activeUnicodeCheck="false" adtcore:responsible="DEVELOPER" adtcore:masterLanguage="EN" adtcore:masterSystem="M62" adtcore:name="MyUsers" adtcore:type="DDLS/DF" adtcore:changedAt="2021-04-14T07:45:34Z" adtcore:version="active" adtcore:createdAt="2021-02-11T00:00:00Z" adtcore:changedBy="SAP" adtcore:createdBy="DEVELOPER" adtcore:description="My Users" adtcore:language="EN" xmlns:abapsource="http://www.sap.com/adt/abapsource" xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:packageRef adtcore:uri="/sap/bc/adt/packages/universe" adtcore:type="DEVC/K" adtcore:name="UNIVERSE" adtcore:packageName="UNIVERSE" adtcore:description="Universe"/>
+</ddl:ddlSource>
+'''
+
 ERROR_XML_PACKAGE_ALREADY_EXISTS='''<?xml version="1.0" encoding="utf-8"?><exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><namespace id="com.sap.adt"/><type id="ExceptionResourceAlreadyExists"/><message lang="EN">Resource Package $SAPCLI_TEST_ROOT does already exist.</message><localizedMessage lang="EN">Resource Package $SAPCLI_TEST_ROOT does already exist.</localizedMessage><properties/></exc:exception>'''
 
 

--- a/test/unit/test_sap_adt_class.py
+++ b/test/unit/test_sap_adt_class.py
@@ -4,6 +4,7 @@ import unittest
 
 from sap import get_logger
 import sap.adt
+import sap.adt.wb
 
 from mock import Connection, Response
 
@@ -135,9 +136,14 @@ class TestADTClass(unittest.TestCase):
         self.include_write_test(lambda clas: clas.test_classes, 'includes/testclasses')
 
     def include_activate_test(self, getter, includes_uri):
-        conn = Connection([EMPTY_RESPONSE_OK])
+        conn = Connection(
+            [
+                EMPTY_RESPONSE_OK,
+                Response(text=GET_CLASS_ADT_XML, status_code=200, headers={})
+            ])
 
         clas = sap.adt.Class(conn, 'ZCL_HELLO_WORLD')
+
         sap.adt.wb.activate(getter(clas))
 
         post_request = conn.execs[0]

--- a/test/unit/test_sap_cli_ddl.py
+++ b/test/unit/test_sap_cli_ddl.py
@@ -6,6 +6,7 @@ from unittest.mock import call, patch, Mock, PropertyMock
 from io import StringIO
 
 import sap.cli.interface
+import sap.cli.datadefinition
 
 from mock import patch_get_print_console_with_buffer
 
@@ -32,6 +33,7 @@ class TestDDLActivate(unittest.TestCase):
         def add_instance(conn, name):
             ddl = Mock()
             ddl.name = name
+            ddl.active = 'active'
 
             instances.append(ddl)
             return ddl

--- a/test/unit/test_sap_cli_include.py
+++ b/test/unit/test_sap_cli_include.py
@@ -18,6 +18,7 @@ from fixtures_adt_program import (
     GET_INCLUDE_PROGRAM_ADT_XML,
     GET_INCLUDE_PROGRAM_WITH_CONTEXT_ADT_XML
 )
+#from test.unit.fixtures_adt_class import GET_CLASS_ADT_XML
 
 FIXTURE_STDIN_REPORT_SRC='* from stdin'
 FIXTURE_FILE_REPORT_SRC='* from file'
@@ -83,21 +84,27 @@ class TestIncludeWrite(unittest.TestCase):
 class TestIncludeActivate(unittest.TestCase):
 
     def test_activate(self):
-        conn = Connection([EMPTY_RESPONSE_OK])
+        conn = Connection([
+            EMPTY_RESPONSE_OK,
+            Response(text=GET_INCLUDE_PROGRAM_ADT_XML.replace('ZHELLO_INCLUDE', 'test_activation'), status_code=200, headers={})
+        ])
 
         args = parse_args('activate', 'test_activation')
         args.execute(conn, args)
 
-        self.assertEqual(len(conn.execs), 1)
+        self.assertEqual(len(conn.execs), 2)
         self.assertIn('test_activation"', conn.execs[0].body)
 
     def test_activate_with_master(self):
-        conn = Connection([EMPTY_RESPONSE_OK])
+        conn = Connection([
+            EMPTY_RESPONSE_OK,
+            Response(text=GET_INCLUDE_PROGRAM_ADT_XML.replace('ZHELLO_INCLUDE', 'test_activation'), status_code=200, headers={})
+        ])
 
         args = parse_args('activate', 'test_activation', '-m', 'MASTER_REPORT')
         args.execute(conn, args)
 
-        self.assertEqual(len(conn.execs), 1)
+        self.assertEqual(len(conn.execs), 2)
         self.assertRegex(conn.execs[0].body, '.*adtcore:uri=[^?]*test_activation\?context=[^"]*master_report".*')
 
 

--- a/test/unit/test_sap_cli_interface.py
+++ b/test/unit/test_sap_cli_interface.py
@@ -7,8 +7,9 @@ from io import StringIO
 
 import sap.cli.interface
 
-from mock import Connection
+from mock import Connection, Response
 from fixtures_adt import EMPTY_RESPONSE_OK, LOCK_RESPONSE_OK
+from fixtures_adt_interface import GET_INTERFACE_ADT_XML
 
 
 FIXTURE_ELEMENTARY_IFACE_XML='''<?xml version="1.0" encoding="UTF-8"?>
@@ -46,11 +47,15 @@ class TestInterfaceCreate(unittest.TestCase):
 class TestInterfaceActivate(unittest.TestCase):
 
     def test_interface_activate_defaults(self):
-        connection = Connection([EMPTY_RESPONSE_OK])
+        connection = Connection([
+            EMPTY_RESPONSE_OK,
+            Response(text=GET_INTERFACE_ADT_XML.replace('ZIF_HELLO_WORLD', 'ZIF_ACTIVATOR'), status_code=200, headers={})
+        ])
+
         args = parse_args('activate', 'ZIF_ACTIVATOR')
         args.execute(connection, args)
 
-        self.assertEqual([(e.method, e.adt_uri) for e in connection.execs], [('POST', '/sap/bc/adt/activation')])
+        self.assertEqual([(e.method, e.adt_uri) for e in connection.execs], [('POST', '/sap/bc/adt/activation'), ('GET', '/sap/bc/adt/oo/interfaces/zif_activator')])
 
         create_request = connection.execs[0]
         self.assertIn('adtcore:uri="/sap/bc/adt/oo/interfaces/zif_activator"', create_request.body)

--- a/test/unit/test_sap_cli_program.py
+++ b/test/unit/test_sap_cli_program.py
@@ -7,8 +7,9 @@ from argparse import ArgumentParser
 
 import sap.cli.program
 
-from mock import Connection
+from mock import Connection, Response
 from fixtures_adt import LOCK_RESPONSE_OK, EMPTY_RESPONSE_OK
+from fixtures_adt_program import GET_EXECUTABLE_PROGRAM_ADT_XML
 
 
 FIXTURE_STDIN_REPORT_SRC='report stdin.\n\n" Salute!\n\nwrite: \'hello, command line!\'\n'
@@ -72,12 +73,15 @@ class TestProgramWrite(unittest.TestCase):
 class TestProgramActivate(unittest.TestCase):
 
     def test_activate(self):
-        conn = Connection([EMPTY_RESPONSE_OK])
+        conn = Connection([
+            EMPTY_RESPONSE_OK,
+            Response(text=GET_EXECUTABLE_PROGRAM_ADT_XML.replace('ZHELLO_WORLD', 'test_activation'), status_code=200, headers={})
+        ])
 
         args = parse_args('activate', 'test_activation')
         args.execute(conn, args)
 
-        self.assertEqual(len(conn.execs), 1)
+        self.assertEqual(len(conn.execs), 2)
         self.assertIn('test_activation', conn.execs[0].body)
 
 

--- a/test/unit/test_sap_cli_rap.py
+++ b/test/unit/test_sap_cli_rap.py
@@ -17,6 +17,7 @@ from infra import generate_parse_args
 
 from mock import Connection, Response, Request
 from fixtures_adt_wb import RESPONSE_ACTIVATION_OK
+from fixtures_adt_businessservice import SERVICE_DEFINITION_ADT_XML
 
 parse_args = generate_parse_args(sap.cli.rap.CommandGroup())
 
@@ -222,7 +223,10 @@ class TestRapDefinition(PatcherTestCase, ConsoleOutputTestCase):
 
         self.patch_console(console=self.console)
 
-        self.connection = Connection([RESPONSE_ACTIVATION_OK])
+        self.connection = Connection([
+            RESPONSE_ACTIVATION_OK,
+            Response(text=SERVICE_DEFINITION_ADT_XML, status_code=200, headers={})
+        ])
         self.param_definition_name = 'EXAMPLE_CONFIG_SRV'
 
     def execute_definition_activate(self):

--- a/test/unit/test_sap_cli_table.py
+++ b/test/unit/test_sap_cli_table.py
@@ -20,7 +20,9 @@ from fixtures_adt_table import (
     WRITE_TABLE_BODY,
     FAKE_LOCK_HANDLE,
     ACTIVATE_TABLE_BODY,
+    TABLE_DEFINITION_ADT_XML
 )
+from fixtures_adt_wb import RESPONSE_ACTIVATION_OK
 
 parse_args = generate_parse_args(sap.cli.table.CommandGroup())
 
@@ -104,7 +106,10 @@ class TestTableActivate(unittest.TestCase):
         return parse_args('activate', *args, **kwargs)
 
     def test_activate(self):
-        connection = Connection()
+        connection = Connection([
+            RESPONSE_ACTIVATION_OK,
+            Response(text=TABLE_DEFINITION_ADT_XML , status_code=200, headers={})
+        ])
 
         the_cmd = self.table_activate_cmd(TABLE_NAME)
         the_cmd.execute(connection, the_cmd)

--- a/test/unit/test_sap_cli_wb.py
+++ b/test/unit/test_sap_cli_wb.py
@@ -17,7 +17,7 @@ class TestObjectActivationWorker(unittest.TestCase):
 
     def setUp(self):
         self.worker = sap.cli.wb.ObjectActivationWorker()
-        self.activated_object = Mock()
+        self.activated_object = Mock(active='inactive') # by default, simulate inactive object
         self.message_builder = MessageBuilder()
         self.stats = sap.cli.wb.ObjectActivationStats()
 
@@ -71,6 +71,8 @@ class TestObjectActivationWorker(unittest.TestCase):
         self.assertEqual(stats.inactive_objects, [])
 
     def test_handle_results_without_messages(self):
+        self.activated_object.active = "active" # simulate activated object
+
         with patch_get_print_console_with_buffer() as fake_console:
             self.worker.handle_results('CL_NO_MESSAGES',
                                        self.activated_object,
@@ -126,6 +128,7 @@ class TestObjectActivationWorker(unittest.TestCase):
 
     def test_handle_results_with_warnings_and_stop(self):
         self.worker.warnings_as_errors = True
+        self.activated_object.active = "active" # simulate activated object
 
         with self.assertRaises(sap.cli.wb.StopObjectActivation) as caught, \
              patch_get_print_console_with_buffer() as fake_console:
@@ -139,6 +142,8 @@ class TestObjectActivationWorker(unittest.TestCase):
         self.assertEqual(caught.exception.stats.errors, 1)
 
     def test_handle_results_with_warnings(self):
+        self.activated_object.active = "active" # simulate activated object
+
         with patch_get_print_console_with_buffer() as fake_console:
             stats = self.worker.handle_results('CL_NO_MESSAGES',
                                        self.activated_object,
@@ -152,6 +157,7 @@ class TestObjectActivationWorker(unittest.TestCase):
     def test_handle_results_with_warnings_as_error_and_ignore(self):
         self.worker.continue_on_errors = True
         self.worker.warnings_as_errors = True
+        self.activated_object.active = "active" # simulate activated object
 
         with patch_get_print_console_with_buffer() as fake_console:
             stats = self.worker.handle_results('CL_NO_MESSAGES',
@@ -164,6 +170,8 @@ class TestObjectActivationWorker(unittest.TestCase):
         self.assertEqual(self.stats.errors, 1)
 
     def test_activate_sequentially(self):
+        self.activated_object.active = "active" # simulate activated object
+
         with patch('sap.adt.wb.try_activate') as fake_try_activate, \
              patch_get_print_console_with_buffer() as fake_console:
 


### PR DESCRIPTION
This change extends object activation request (POST) of additional request (GET), whose purpose is to fetch object properties immediatelly after activation and check generic attribute `adtcore:version`. Value of this attribute clearly determines if activation was successfull (`active`) or not (`inactive`).

This enhancement was necessary for table activations, since current approach (checkin of `generated` attribute) didn't work for objects of type table.