### PR TITLE
gcts: change the output of property get command

### DIFF
--- a/sap/cli/gcts.py
+++ b/sap/cli/gcts.py
@@ -154,25 +154,20 @@ class PropertyCommandGroup(sap.cli.core.CommandGroup):
 def get_properties(connection, args):
     """Get all repository properties"""
 
+    console = sap.cli.core.get_console()
     try:
         repo = get_repository(connection, args.package)
 
-        columns = (
-            sap.cli.helpers.TableWriter.Columns()
-            ('name', 'Name')
-            ('rid', 'RID')
-            ('branch', 'Branch')
-            ('head', 'Commit')
-            ('status', 'Status')
-            ('vsid', 'vSID')
-            ('role', 'ROLE')
-            ('url', 'URL')
-            .done()
-        )
-
-        sap.cli.helpers.TableWriter([repo], columns).printout(sap.cli.core.get_console())
+        console.printout(f'Name: {repo.name}')
+        console.printout(f'RID: {repo.rid}')
+        console.printout(f'Branch: {repo.branch}')
+        console.printout(f'Commit: {repo.head}')
+        console.printout(f'Status: {repo.status}')
+        console.printout(f'vSID: {repo.vsid}')
+        console.printout(f'Role: {repo.role}')
+        console.printout(f'URL: {repo.url}')
     except SAPCliError as ex:
-        sap.cli.core.printout(str(ex))
+        console.printout(str(ex))
         return 1
 
     return 0

--- a/test/unit/test_sap_cli_gcts.py
+++ b/test/unit/test_sap_cli_gcts.py
@@ -942,9 +942,14 @@ class TestgCTSRepoGetProperty(PatcherTestCase, ConsoleOutputTestCase):
 
         self.assertEqual(exit_code, 0)
         self.assertConsoleContents(self.console, stdout=
-'''Name | RID | Branch | Commit | Status | vSID | ROLE | URL                       
---------------------------------------------------------------------------------
-name | rid | branch | head   | status | vsid | role | http://github.com/name.git
+'''Name: name
+RID: rid
+Branch: branch
+Commit: head
+Status: status
+vSID: vsid
+Role: role
+URL: http://github.com/name.git
 ''')
 
     @patch('sap.rest.gcts.simple.fetch_repos')
@@ -956,9 +961,14 @@ name | rid | branch | head   | status | vsid | role | http://github.com/name.git
 
         self.assertEqual(exit_code, 0)
         self.assertConsoleContents(self.console, stdout=
-'''Name | RID | Branch | Commit | Status | vSID | ROLE | URL                       
---------------------------------------------------------------------------------
-name | rid | branch | head   | status | vsid | role | http://github.com/name.git
+'''Name: name
+RID: rid
+Branch: branch
+Commit: head
+Status: status
+vSID: vsid
+Role: role
+URL: http://github.com/name.git
 ''')
 
     @patch('sap.cli.gcts.get_repository')


### PR DESCRIPTION
Instead of utilizing a table to print properties, the command prints each property on a new line.