### PR TITLE
gcts: implement repo branch operations

### DIFF
--- a/doc/commands/gcts.md
+++ b/doc/commands/gcts.md
@@ -16,6 +16,9 @@ sapcli's implementation forces use of packages as git repositories.
 12. [repo set-url](#repo-set-url)
 13. [repo property get](#repo-property-get)
 14. [repo property set](#repo-property-set)
+15. [repo branch create](#repo-branch-create)
+16. [repo branch delete](#repo-branch-delete)
+17. [repo branch list](#repo-branch-list)
 
 ## repolist
 
@@ -185,6 +188,50 @@ sapcli gcts repo property set PACKAGE PROPERTY_NAME VALUE
 - `PACKAGE`: The repository name
 - `PROPERTY_NAME`: The name of the property that is to be changed
 - `VALUE`: New value for the specified property
+
+## repo branch create
+
+Create and switch to the new branch. By default, the command creates `local` and `remote` branch.
+This behavior can be overriden by `--local-only` argument.
+
+```bash
+sapcli gcts repo branch create PACKAGE NAME [--symbolic] [--peeled] [--local-only] [-f|--format] {HUMAN|JSON}
+```
+
+**Parameters**:
+- `PACKAGE`: The repository name
+- `NAME`: The name of a new branch
+- `--symbolic`: The new branch will be symbolic
+- `--peeled`: The new branch will be peeled
+- `--local-only`: Create only `local` branch.
+- `--format`: The format of the command's output
+
+## repo branch delete
+
+Delete the branch. Note, the branch cannot be active.
+
+```bash
+sapcli gcts repo branch delete PACKAGE NAME [-f|--format] {HUMAN|JSON}
+```
+
+**Parameters**:
+- `PACKAGE`: The repository name
+- `NAME`: The name of a new branch
+- `--format`: The format of the command's output
+
+## repo branch list
+
+List branches of a repository. The active branch is marked by `*` only in `HUMAN` format.
+
+```bash
+sapcli gcts repo branch list PACKAGE [-a|--all] [-r|--remote] [-f|--format] {HUMAN|JSON}
+```
+
+**Parameters**:
+- `PACKAGE`: The repository name
+- `--all`: List all branches
+- `--remote`: List `remote` branches only
+- `--format`: The format of the command's output
 
 
 # Deprecated

--- a/sap/rest/gcts/remote_repo.py
+++ b/sap/rest/gcts/remote_repo.py
@@ -451,3 +451,34 @@ class Repository:
             raise SAPCliError(f'Cannot edit property "{property_name}".')
 
         return self._set_item(property_name, value)
+
+    def create_branch(self, branch_name, symbolic=False, peeled=False, local_only=False):
+        """Create new branch"""
+
+        def _call_create(branch_type):
+            body = {
+                'branch': branch_name,
+                'type': branch_type,
+                'isSymbolic': symbolic,
+                'isPeeled': peeled,
+            }
+
+            return self._http.post_obj_as_json('branches', json=body)
+
+        response = _call_create('local') if local_only else _call_create('global')
+        return response.json()['branch']
+
+    def delete_branch(self, branch_name: str):
+        """Delete branch of repository"""
+
+        return self._http.delete(f'branches/{branch_name}').json()
+
+    def list_branches(self):
+        """List branches of repository"""
+
+        response = self._http.get_json('branches')
+        branches = response.get('branches')
+        if branches is None:
+            raise SAPCliError("gCTS response does not contain 'branches'")
+
+        return branches


### PR DESCRIPTION
New command group can create, delete and list branches of a repository.

In addition to creating a branch the 'create' command switches to the newly created branch. The switch is done automatically by the 'create' REST call and the documentation does not specify any flag to disable it.