### PR TITLE
gcts: implement system config operations

### DIFF
--- a/doc/commands/gcts.md
+++ b/doc/commands/gcts.md
@@ -19,6 +19,10 @@ sapcli's implementation forces use of packages as git repositories.
 15. [repo branch create](#repo-branch-create)
 16. [repo branch delete](#repo-branch-delete)
 17. [repo branch list](#repo-branch-list)
+18. [system config get](#system-config-get)
+19. [system config list](#system-config-list)
+20. [system config set](#system-config-set)
+21. [system config unset](#system-config-unset)
 
 ## repolist
 
@@ -231,6 +235,56 @@ sapcli gcts repo branch list PACKAGE [-a|--all] [-r|--remote] [-f|--format] {HUM
 - `PACKAGE`: The repository name
 - `--all`: List all branches
 - `--remote`: List `remote` branches only
+- `--format`: The format of the command's output
+
+## system config get
+
+Get the specific system configuration property.
+
+```bash
+sapcli gcts system config get KEY [-f|--format] {HUMAN|JSON}
+```
+
+**Parameters**:
+- `KEY`: The identifier of configuration property
+- `--format`: The format of the command's output
+
+
+## system config list
+
+List the system configuration.
+
+```bash
+sapcli gcts system config list [-f|--format] {HUMAN|JSON}
+```
+
+**Parameters**:
+- `--format`: The format of the command's output
+
+## system config set
+
+Create or update the system configuration property.
+
+```bash
+sapcli gcts system config set KEY VALUE [-f|--format] {HUMAN|JSON}
+```
+
+**Parameters**:
+- `KEY`: The identifier of configuration property
+- `VALUE`: The value that will be assigned to the property
+- `--format`: The format of the command's output
+
+
+## system config unset
+
+Delete the system configuration property.
+
+```bash
+sapcli gcts system config unset KEY [-f|--format] {HUMAN|JSON}
+```
+
+**Parameters**:
+- `KEY`: The identifier of configuration property
 - `--format`: The format of the command's output
 
 

--- a/sap/cli/gcts.py
+++ b/sap/cli/gcts.py
@@ -405,6 +405,126 @@ def activities(connection, args):
     return 0
 
 
+class ConfigCommandGroup(sap.cli.core.CommandGroup):
+    """Container for config commands."""
+
+    def __init__(self):
+        super().__init__('config')
+
+
+def _print_config_property(console, config_property, output_format):
+    """Print system configuration property"""
+
+    if output_format == 'JSON':
+        console.printout(sap.cli.core.json_dumps(config_property))
+    else:
+        console.printout(f'Key: {config_property["key"]}')
+        console.printout(f'Value: {config_property["value"]}')
+
+
+@ConfigCommandGroup.argument('-f', '--format', type=str, choices=['HUMAN', 'JSON'], default='HUMAN')
+@ConfigCommandGroup.argument('key', type=str)
+@ConfigCommandGroup.command('get')
+def get_system_config_property(connection, args):
+    """Get configuration property value for given key"""
+
+    console = sap.cli.core.get_console()
+    try:
+        config_property = sap.rest.gcts.simple.get_system_config_property(connection, args.key.upper())
+    except SAPCliError as ex:
+        console.printerr(str(ex))
+        return 1
+
+    _print_config_property(console, config_property, args.format.upper())
+
+    return 0
+
+
+@ConfigCommandGroup.argument('-f', '--format', type=str, choices=['HUMAN', 'JSON'], default='HUMAN')
+@ConfigCommandGroup.command('list')
+def list_system_config(connection, args):
+    """List system configuration"""
+    console = sap.cli.core.get_console()
+    try:
+        config_list = sap.rest.gcts.simple.list_system_config(connection)
+    except SAPCliError as ex:
+        console.printerr(str(ex))
+        return 1
+
+    if args.format.upper() == 'JSON':
+        console.printout(sap.cli.core.json_dumps(config_list))
+    else:
+        columns = (
+            sap.cli.helpers.TableWriter.Columns()
+            ('key', 'Key')
+            ('value', 'Value')
+            ('category', 'Category')
+            ('changedAt', 'Changed At')
+            ('changedBy', 'Changed By')
+            .done()
+        )
+
+        tw = sap.cli.helpers.TableWriter(config_list, columns)
+        tw.printout(console)
+
+    return 0
+
+
+@ConfigCommandGroup.argument('-f', '--format', type=str, choices=['HUMAN', 'JSON'], default='HUMAN')
+@ConfigCommandGroup.argument('value', type=str)
+@ConfigCommandGroup.argument('key', type=str)
+@ConfigCommandGroup.command('set')
+def set_system_config_property(connection, args):
+    """Create or update the configuration property"""
+
+    console = sap.cli.core.get_console()
+    try:
+        config_property = sap.rest.gcts.simple.set_system_config_property(connection, args.key.upper(), args.value)
+    except SAPCliError as ex:
+        console.printerr(str(ex))
+        return 1
+
+    _print_config_property(console, config_property, args.format.upper())
+
+    return 0
+
+
+@ConfigCommandGroup.argument('-f', '--format', type=str, choices=['HUMAN', 'JSON'], default='HUMAN')
+@ConfigCommandGroup.argument('key', type=str)
+@ConfigCommandGroup.command('unset')
+def delete_system_config_property(connection, args):
+    """Delete configuration property"""
+
+    console = sap.cli.core.get_console()
+    try:
+        response = sap.rest.gcts.simple.delete_system_config_property(connection, args.key.upper())
+    except SAPCliError as ex:
+        console.printerr(str(ex))
+        return 1
+
+    if args.format.upper() == 'JSON':
+        console.printout(sap.cli.core.json_dumps(response))
+    else:
+        console.printout(f'Config property "{args.key.upper()}" was unset.')
+
+    return 0
+
+
+class SystemCommandGroup(sap.cli.core.CommandGroup):
+    """Container for system commands."""
+
+    def __init__(self):
+        super().__init__('system')
+
+        self.config_grp = ConfigCommandGroup()
+
+    def install_parser(self, arg_parser):
+        system_group = super().install_parser(arg_parser)
+
+        config_parser = system_group.add_parser(self.config_grp.name)
+        self.config_grp.install_parser(config_parser)
+
+
 class CommandGroup(sap.cli.core.CommandGroup):
     """Adapter converting command line parameters to sap.rest.gcts
        methods calls.
@@ -415,6 +535,7 @@ class CommandGroup(sap.cli.core.CommandGroup):
 
         self.user_grp = UserCommandGroup()
         self.repo_grp = RepoCommandGroup()
+        self.system_grp = SystemCommandGroup()
 
     def install_parser(self, arg_parser):
         gcts_group = super().install_parser(arg_parser)
@@ -424,6 +545,9 @@ class CommandGroup(sap.cli.core.CommandGroup):
 
         repo_parser = gcts_group.add_parser(self.repo_grp.name)
         self.repo_grp.install_parser(repo_parser)
+
+        system_parser = gcts_group.add_parser(self.system_grp.name)
+        self.system_grp.install_parser(system_parser)
 
 
 @CommandGroup.command()

--- a/sap/rest/connection.py
+++ b/sap/rest/connection.py
@@ -223,3 +223,10 @@ class Connection:
 
         body = json.dumps(obj)
         return self.execute('POST', uri_path, content_type='application/json', body=body, accept=accept)
+
+    def delete_json(self, uri_path, params=None):
+        """Executes a DELETE HTTP request ith the headers Accept = application/json.
+        """
+
+        response = self.execute('DELETE', uri_path, accept='application/json', params=params)
+        return response.json()

--- a/sap/rest/gcts/simple.py
+++ b/sap/rest/gcts/simple.py
@@ -142,3 +142,46 @@ def delete_user_credentials(connection, api_url):
     }
 
     connection.post_obj_as_json('user/credentials', body)
+
+
+def get_system_config_property(connection, config_key):
+    """Get configuration property value for given key"""
+
+    response = connection.get_json(f'system/config/{config_key}')
+    config_value = response.get('result')
+    if config_value is None:
+        raise SAPCliError("gCTS response does not contain 'result'")
+
+    return config_value
+
+
+def list_system_config(connection):
+    """List system configuration"""
+
+    response = connection.get_json('system')
+    system = response.get('result')
+    if system is None:
+        raise SAPCliError("gCTS response does not contain 'result'")
+
+    return system.get('config', [])
+
+
+def set_system_config_property(connection, config_key, value):
+    """Create or update the configuration property"""
+
+    body = {
+        'key': config_key,
+        'value': value,
+    }
+    response = connection.post_obj_as_json('system/config', body).json()
+    config_value = response.get('result')
+    if config_value is None:
+        raise SAPCliError("gCTS response does not contain 'result'")
+
+    return config_value
+
+
+def delete_system_config_property(connection, config_key):
+    """Delete configuration property"""
+
+    return connection.delete_json(f'system/config/{config_key}')

--- a/test/unit/test_sap_cli_gcts.py
+++ b/test/unit/test_sap_cli_gcts.py
@@ -1552,3 +1552,206 @@ class TestgCTSUserDeleteCredentials(PatcherTestCase, ConsoleOutputTestCase):
         the_cmd.execute(self.fake_connection, the_cmd)
 
         fake_delete_credentials.asser_called_once_with(self.fake_connection, api_url)
+
+
+class TestgCTSGetSystemConfigProperty(PatcherTestCase, ConsoleOutputTestCase):
+
+    def setUp(self):
+        super().setUp()
+        ConsoleOutputTestCase.setUp(self)
+
+        assert self.console is not None
+
+        self.patch_console(console=self.console)
+        self.fake_connection = Mock()
+
+        self.config_key = 'THE_KEY'
+        self.config_value = 'the_value'
+        self.expected_property = {'key': self.config_key, 'value': self.config_value}
+
+        self.fake_get_config_property = self.patch('sap.rest.gcts.simple.get_system_config_property')
+        self.fake_get_config_property.return_value = self.expected_property
+
+    def get_config_property_cmd(self, *args, **kwargs):
+        return parse_args('system', 'config', 'get', *args, **kwargs)
+
+    def test_get_system_config_property(self):
+        the_cmd = self.get_config_property_cmd(self.config_key)
+        exit_code = the_cmd.execute(self.fake_connection, the_cmd)
+
+        self.assertEqual(exit_code, 0)
+        self.fake_get_config_property.assert_called_once_with(self.fake_connection, self.config_key)
+        self.assertConsoleContents(self.console, stdout=
+f'''Key: {self.config_key}
+Value: {self.config_value}
+''')
+
+    def test_get_system_config_property_json(self):
+        the_cmd = self.get_config_property_cmd(self.config_key, '-f', 'JSON')
+        exit_code = the_cmd.execute(self.fake_connection, the_cmd)
+
+        self.assertEqual(exit_code, 0)
+        self.fake_get_config_property.assert_called_once_with(self.fake_connection, self.config_key)
+        self.assertConsoleContents(self.console,
+                                   stdout='{}\n'.format(json.dumps(self.expected_property, indent=2)))
+
+    def test_get_system_config_property_request_error(self):
+        self.fake_get_config_property.side_effect = sap.cli.gcts.SAPCliError('Request error')
+
+        the_cmd = self.get_config_property_cmd(self.config_key)
+        exit_code = the_cmd.execute(self.fake_connection, the_cmd)
+
+        self.assertEqual(exit_code, 1)
+        self.fake_get_config_property.assert_called_once_with(self.fake_connection, self.config_key)
+        self.assertConsoleContents(self.console, stderr='Request error\n')
+
+
+class TestgCTSListSystemConfig(PatcherTestCase, ConsoleOutputTestCase):
+
+    def setUp(self):
+        super().setUp()
+        ConsoleOutputTestCase.setUp(self)
+
+        assert self.console is not None
+
+        self.patch_console(console=self.console)
+        self.fake_connection = Mock()
+
+        self.expected_config = [
+            {'key': 'THE_KEY1', 'value': 'the_value1', 'category': 'SYSTEM', 'changedAt': 2022, 'changedBy': 'Test'},
+            {'key': 'THE_KEY2', 'value': 'the_value2', 'category': 'SYSTEM', 'changedAt': 2022, 'changedBy': 'Test'}
+        ]
+        self.fake_list_system_config = self.patch('sap.rest.gcts.simple.list_system_config')
+        self.fake_list_system_config.return_value = self.expected_config
+
+    def list_system_config_cmd(self, *args, **kwargs):
+        return parse_args('system', 'config', 'list', *args, **kwargs)
+
+    def test_list_system_config(self):
+        the_cmd = self.list_system_config_cmd()
+        exit_code = the_cmd.execute(self.fake_connection, the_cmd)
+
+        self.assertEqual(exit_code, 0)
+        self.fake_list_system_config.assert_called_once_with(self.fake_connection)
+        self.assertConsoleContents(self.console, stdout=
+'''Key      | Value      | Category | Changed At | Changed By
+----------------------------------------------------------
+THE_KEY1 | the_value1 | SYSTEM   | 2022       | Test      
+THE_KEY2 | the_value2 | SYSTEM   | 2022       | Test      
+''')
+
+    def test_list_system_config_json(self):
+        the_cmd = self.list_system_config_cmd('-f', 'JSON')
+        exit_code = the_cmd.execute(self.fake_connection, the_cmd)
+
+        self.assertEqual(exit_code, 0)
+        self.fake_list_system_config.assert_called_once_with(self.fake_connection)
+        self.assertConsoleContents(self.console,
+                                   stdout='{}\n'.format(json.dumps(self.expected_config, indent=2)))
+
+    def test_list_system_config_request_error(self):
+        self.fake_list_system_config.side_effect = sap.cli.gcts.SAPCliError('Request error')
+
+        the_cmd = self.list_system_config_cmd()
+        exit_code = the_cmd.execute(self.fake_connection, the_cmd)
+
+        self.assertEqual(exit_code, 1)
+        self.fake_list_system_config.assert_called_once_with(self.fake_connection)
+        self.assertConsoleContents(self.console, stderr='Request error\n')
+
+
+class TestgCTSSetSystemConfigProperty(PatcherTestCase, ConsoleOutputTestCase):
+
+    def setUp(self):
+        super().setUp()
+        ConsoleOutputTestCase.setUp(self)
+
+        assert self.console is not None
+
+        self.patch_console(console=self.console)
+        self.fake_connection = Mock()
+
+        self.config_key = 'THE_KEY'
+        self.config_value = 'the_value'
+        self.expected_property = {'key': self.config_key, 'value': self.config_value}
+
+        self.fake_set_config_property = self.patch('sap.rest.gcts.simple.set_system_config_property')
+        self.fake_set_config_property.return_value = self.expected_property
+
+    def set_config_property_cmd(self, *args, **kwargs):
+        return parse_args('system', 'config', 'set', *args, **kwargs)
+
+    def test_set_system_config_property(self):
+        the_cmd = self.set_config_property_cmd(self.config_key, self.config_value)
+        exit_code = the_cmd.execute(self.fake_connection, the_cmd)
+
+        self.assertEqual(exit_code, 0)
+        self.fake_set_config_property.assert_called_once_with(self.fake_connection, self.config_key, self.config_value)
+        self.assertConsoleContents(self.console, stdout=
+f'''Key: {self.config_key}
+Value: {self.config_value}
+''')
+
+    def test_set_system_config_json(self):
+        the_cmd = self.set_config_property_cmd(self.config_key, self.config_value, '-f', 'JSON')
+        exit_code = the_cmd.execute(self.fake_connection, the_cmd)
+
+        self.assertEqual(exit_code, 0)
+        self.fake_set_config_property.assert_called_once_with(self.fake_connection, self.config_key, self.config_value)
+        self.assertConsoleContents(self.console,
+                                   stdout='{}\n'.format(json.dumps(self.expected_property, indent=2)))
+
+    def test_set_system_config_request_error(self):
+        self.fake_set_config_property.side_effect = sap.cli.gcts.SAPCliError('Request error')
+
+        the_cmd = self.set_config_property_cmd(self.config_key, self.config_value)
+        exit_code = the_cmd.execute(self.fake_connection, the_cmd)
+
+        self.assertEqual(exit_code, 1)
+        self.fake_set_config_property.assert_called_once_with(self.fake_connection, self.config_key, self.config_value)
+        self.assertConsoleContents(self.console, stderr='Request error\n')
+
+
+class TestgCTSDeleteSystemConfigProperty(PatcherTestCase, ConsoleOutputTestCase):
+
+    def setUp(self):
+        super().setUp()
+        ConsoleOutputTestCase.setUp(self)
+
+        assert self.console is not None
+
+        self.patch_console(console=self.console)
+        self.fake_connection = Mock()
+
+        self.config_key = 'THE_KEY'
+        self.fake_delete_config_property = self.patch('sap.rest.gcts.simple.delete_system_config_property')
+        self.fake_delete_config_property.return_value = {}
+
+    def delete_config_property_cmd(self, *args, **kwargs):
+        return parse_args('system', 'config', 'unset', *args, **kwargs)
+
+    def test_delete_system_config_property(self):
+        the_cmd = self.delete_config_property_cmd(self.config_key)
+        exit_code = the_cmd.execute(self.fake_connection, the_cmd)
+
+        self.assertEqual(exit_code, 0)
+        self.fake_delete_config_property.assert_called_once_with(self.fake_connection, self.config_key)
+        self.assertConsoleContents(self.console, stdout=f'Config property "{self.config_key}" was unset.\n')
+
+    def test_delete_system_config_property_json(self):
+        the_cmd = self.delete_config_property_cmd(self.config_key, '-f', 'JSON')
+        exit_code = the_cmd.execute(self.fake_connection, the_cmd)
+
+        self.assertEqual(exit_code, 0)
+        self.fake_delete_config_property.assert_called_once_with(self.fake_connection, self.config_key)
+        self.assertConsoleContents(self.console, stdout='{}\n')
+
+    def test_delete_system_config_property_request_error(self):
+        self.fake_delete_config_property.side_effect = sap.cli.gcts.SAPCliError('Request error')
+
+        the_cmd = self.delete_config_property_cmd(self.config_key)
+        exit_code = the_cmd.execute(self.fake_connection, the_cmd)
+
+        self.assertEqual(exit_code, 1)
+        self.fake_delete_config_property.assert_called_once_with(self.fake_connection, self.config_key)
+        self.assertConsoleContents(self.console, stderr='Request error\n')

--- a/test/unit/test_sap_rest_gcts.py
+++ b/test/unit/test_sap_rest_gcts.py
@@ -1083,3 +1083,136 @@ class TestgCTSSimpleAPI(GCTSTestSetUp, unittest.TestCase):
         )
 
         self.assertEqual(response, None)
+
+    def test_simple_get_system_config_property(self):
+        config_key = 'THE_KEY'
+        expected_response = {
+            'key': config_key,
+            'value': 'the_value'
+        }
+
+        self.conn.set_responses([
+            Response.with_json({'result': expected_response})
+        ])
+
+        response = sap.rest.gcts.simple.get_system_config_property(self.conn, config_key)
+        self.assertEqual(response, expected_response)
+
+        self.conn.execs[0].assertEqual(
+            Request.get_json(
+                uri=f'system/config/{config_key}',
+            ),
+            self
+        )
+
+    def test_simple_get_system_config_property_no_result(self):
+        self.conn.set_responses([
+            Response.with_json({})
+        ])
+
+        with self.assertRaises(sap.rest.errors.SAPCliError) as cm:
+            sap.rest.gcts.simple.get_system_config_property(self.conn, 'THE_KEY')
+
+        self.assertEqual(str(cm.exception), "gCTS response does not contain 'result'")
+
+    def test_simple_list_system_config(self):
+        expected_response = [
+            {
+                'key': 'THE_KEY1',
+                'value': 'THE_VALUE1',
+                'category': 'CATEGORY',
+                'changedAt': 20220101000000,
+                'changedBy': 'TEST',
+            },
+            {
+                'key': 'THE_KEY2',
+                'value': 'THE_VALUE2',
+                'category': 'CATEGORY',
+                'changedAt': 20220101000000,
+                'changedBy': 'TEST',
+            }
+        ]
+        self.conn.set_responses([
+            Response.with_json({'result': {'config': expected_response}})
+        ])
+
+        response = sap.rest.gcts.simple.list_system_config(self.conn)
+        self.assertEqual(response, expected_response)
+
+        self.conn.execs[0].assertEqual(
+            Request.get_json('system'),
+            self
+        )
+
+    def test_simple_list_system_config_no_config(self):
+        self.conn.set_responses([
+            Response.with_json({'result': {}})
+        ])
+
+        response = sap.rest.gcts.simple.list_system_config(self.conn)
+        self.assertEqual(response, [])
+
+        self.conn.execs[0].assertEqual(
+            Request.get_json('system'),
+            self
+        )
+
+    def test_simple_list_system_config_no_result(self):
+        self.conn.set_responses([
+            Response.with_json({})
+        ])
+
+        with self.assertRaises(sap.rest.errors.SAPCliError) as cm:
+            sap.rest.gcts.simple.list_system_config(self.conn)
+
+        self.assertEqual(str(cm.exception), "gCTS response does not contain 'result'")
+
+    def test_simple_set_system_config_property(self):
+        config_key = 'THE_KEY'
+        value = 'the_value'
+        expected_response = {
+            'key': config_key,
+            'value': value
+        }
+
+        self.conn.set_responses([
+            Response.with_json({'result': expected_response})
+        ])
+
+        response = sap.rest.gcts.simple.set_system_config_property(self.conn, config_key, value)
+        self.assertEqual(response, expected_response)
+
+        self.conn.execs[0].assertEqual(
+            Request.post_json(
+                uri='system/config',
+                body={'key': config_key, 'value': value}
+            ),
+            self
+        )
+
+    def test_simple_set_system_config_property_no_result(self):
+        self.conn.set_responses([
+            Response.with_json({})
+        ])
+
+        with self.assertRaises(sap.rest.errors.SAPCliError) as cm:
+            sap.rest.gcts.simple.set_system_config_property(self.conn, 'THE_KEY', 'the_value')
+
+        self.assertEqual(str(cm.exception), "gCTS response does not contain 'result'")
+
+    def test_simple_delete_system_config_property(self):
+        config_key = 'THE_KEY'
+        self.conn.set_responses([
+            Response.with_json({})
+        ])
+
+        response = sap.rest.gcts.simple.delete_system_config_property(self.conn, config_key)
+        self.assertEqual(response, {})
+
+        self.conn.execs[0].assertEqual(
+            Request.delete(
+                uri=f'system/config/{config_key}',
+                headers={'Accept': 'application/json'}
+            ),
+            self
+        )


### PR DESCRIPTION
New command group contains get, list, set and unset commands for the management of the system configuration.

I have added a wrapper for DELETE HTTP request to the GCTS connection in order to simplify DELETE calls.