### PR TITLE
gcts: fix listing configuration using URL

### DIFF
--- a/sap/cli/gcts.py
+++ b/sap/cli/gcts.py
@@ -91,7 +91,9 @@ def get_repository(connection, package):
         if len(repositories) > 1:
             raise SAPCliError(f'Cannot uniquely identify the package based on the URL "{package}".')
 
-        return repositories[0]
+        repo = repositories[0]
+        repo.wipe_data()
+        return repo
 
     return Repository(connection, package)
 

--- a/test/unit/test_sap_cli_gcts.py
+++ b/test/unit/test_sap_cli_gcts.py
@@ -124,6 +124,7 @@ class TestgCTSGetRepository(PatcherTestCase, unittest.TestCase):
 
         self.assertEqual(repo, fake_repo)
         self.fake_fetch_repos.assert_called_once_with(self.connection)
+        repo.wipe_data.assert_called_once()
 
     def test_get_repository_url_https(self):
         repo_name = 'the_repo'
@@ -134,6 +135,7 @@ class TestgCTSGetRepository(PatcherTestCase, unittest.TestCase):
 
         self.assertEqual(repo, fake_repo)
         self.fake_fetch_repos.assert_called_once_with(self.connection)
+        repo.wipe_data.assert_called_once()
 
     def test_get_repository_url_not_found(self):
         repo_url = 'http://github.com/the_repo.git'


### PR DESCRIPTION
The problem was that, when URL was used the repository already had cached some data, but not config. That meant that on accessing config the fetch_data() was not triggered which led to config beeing None.

Simply deleting cached data upon get the repository instances solved the problem.