### PR TITLE
Allow changing Alias for users

### DIFF
--- a/sap/rfc/user.py
+++ b/sap/rfc/user.py
@@ -176,6 +176,11 @@ class UserBuilder:
         add_to_dict_if_not_present(password, 'BAPIPWD', '')
         params['PASSWORD'] = password
 
+    def _rfc_params_add_alias(self, params):
+        alias = copy_dict_or_new(self._alias)
+        add_to_dict_if_not_present(alias, 'USERALIAS', '')
+        params['ALIAS'] = alias
+
     def build_rfc_params(self) -> RFCParams:
         """Creates RFC parameters for Creating users"""
 
@@ -191,9 +196,7 @@ class UserBuilder:
 
         self._rfc_params_add_password(params)
 
-        alias = copy_dict_or_new(self._alias)
-        add_to_dict_if_not_present(alias, 'USERALIAS', '')
-        params['ALIAS'] = alias
+        self._rfc_params_add_alias(params)
 
         logondata = copy_dict_or_new(self._logondata_data)
         add_to_dict_if_not_present(logondata, 'GLTGV', today_sap_date())
@@ -211,6 +214,10 @@ class UserBuilder:
         if self._password:
             self._rfc_params_add_password(params)
             params['PASSWORDX'] = {'BAPIPWD': 'X'}
+
+        if self._alias:
+            self._rfc_params_add_alias(params)
+            params['ALIASX'] = {'BAPIALIAS': 'X'}
 
         return params
 

--- a/test/unit/test_sap_rfc_user.py
+++ b/test/unit/test_sap_rfc_user.py
@@ -162,6 +162,25 @@ class TestUserBuilder(unittest.TestCase):
             'USERNAME': username,
         })
 
+    def test_change_parameters_alias(self):
+        username = 'FOO'
+        alias = 'FOOBAR'
+
+        self.assertEqual(self.builder, self.builder.set_username(username))
+        self.assertEqual(self.builder, self.builder.set_alias(alias))
+
+        params = self.builder.build_change_rfc_params()
+
+        self.assertEqual(params, {
+            'USERNAME': username,
+            'ALIAS': {
+                'USERALIAS': alias
+            },
+            'ALIASX': {
+                'BAPIALIAS': 'X'
+            }
+        })
+
 
 class TestUserRoleAssignmentBuilder(unittest.TestCase):
 


### PR DESCRIPTION
It is possible to change user's alias using an RFC call now. 

Should I also update CLI? If so, could you please explain how? I am not sure if we want to keep `nargs='?'` or not. 