### PR TITLE
Allow setting productive password for all users types

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -100,3 +100,4 @@ or as the environment variable `SAP_PASSWORD`, sapcli will prompt you for it.
 - `SAPCLI_LOG_LEVEL` : pass the desired log level - the lower number the more
   messages (`CRITICAL=50, ERROR=40, WARNING=30, INFO=20, DEBUG=10, NOTSET=0`)
 - `SAPCLI_HTTP_TIMEOUT` : floating point number representing timeout for HTTP requests; default=900s
+- `SAPCLI_ABAP_USER_DUMMY_PASSWORD` : string representing a dummy password which is used as a temporary password when changing user's password to productive; default='DummyPwd123!'

--- a/sap/adt/cts.py
+++ b/sap/adt/cts.py
@@ -5,7 +5,7 @@ import xml.sax
 from xml.sax.handler import ContentHandler
 from xml.sax.saxutils import escape
 
-from typing import NamedTuple, Any, List, Tuple
+from typing import NamedTuple, Any, List, Optional, Tuple
 
 from sap import get_logger
 from sap.errors import SAPCliError
@@ -112,8 +112,9 @@ class WorkbenchRequestResponseCreate(NamedTuple):
 class AbstractWorkbenchRequest:
     """Workbench request"""
 
-    def __init__(self, connection, number: str, owner: str = None,
-                 description: str = None, status: str = None, target: str = None):
+    def __init__(self, connection, number: str, owner: Optional[str] = None,
+                 description: Optional[str] = None, status: Optional[str] = None,
+                 target: Optional[str] = None):
         """
         Parameters:
           - status: single character from the set R,D,?

--- a/sap/adt/object_factory.py
+++ b/sap/adt/object_factory.py
@@ -1,6 +1,6 @@
 """Create instances of ADT object proxies by various names"""
 
-from typing import Callable, Dict, List, cast
+from typing import Callable, Dict, List, Optional, cast
 
 import sap.adt
 import sap.adt.core
@@ -15,7 +15,7 @@ class ADTObjectFactory:
     """Factory producing ADT object Proxies.
     """
 
-    def __init__(self, connection: sap.adt.core.Connection, builders: ADTObjectBuilderDictType = None):
+    def __init__(self, connection: sap.adt.core.Connection, builders: Optional[ADTObjectBuilderDictType] = None):
         self._connection = connection
         if builders:
             self._builders = builders

--- a/test/unit/test_sap_cli_user.py
+++ b/test/unit/test_sap_cli_user.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
-from unittest.mock import MagicMock, patch, Mock, PropertyMock
+from unittest.mock import MagicMock, patch, Mock, PropertyMock, call
 
 import sap.cli.user
 from sap.rfc.user import today_sap_date
@@ -97,7 +97,7 @@ class TestUserChange(PatcherTestCase, ConsoleOutputTestCase):
         self.patch_console(console=self.console)
         self.conn = Mock()
 
-    def test_create_ok(self):
+    def test_change_ok(self):
         self.conn.call.return_value = {
             'RETURN': [create_bapiret_info('User changed')],
         }
@@ -106,11 +106,11 @@ class TestUserChange(PatcherTestCase, ConsoleOutputTestCase):
 
         args.execute(self.conn, args)
 
-        self.conn.call.assert_called_once_with('BAPI_USER_CHANGE',
-                USERNAME='ANZEIGER',
-                PASSWORD={'BAPIPWD': 'Victory1!'},
-                PASSWORDX={'BAPIPWD': 'X'},
-        )
+        self.assertEqual(
+            self.conn.call.call_args_list,
+            [call('BAPI_USER_GET_DETAIL', USERNAME='ANZEIGER'),
+             call('BAPI_USER_CHANGE', USERNAME='ANZEIGER',
+                PASSWORD={'BAPIPWD': 'Victory1!'}, PASSWORDX={'BAPIPWD': 'X'})])
 
         self.assertConsoleContents(
                 console=self.console,


### PR DESCRIPTION
Now it is possible to set productive password also for users of type Dialog or Communications Data. This needs to be done as a two step process.  In the first step a dummy password is used because we do not know the actual user's password, but we need it. In the second step this dummy password is changed to a new password which now became the productive password for the user. 