### PR TITLE
tree-wide: update JUnit AUnit output for Skipped tests

### DIFF
--- a/sap/adt/aunit.py
+++ b/sap/adt/aunit.py
@@ -275,6 +275,12 @@ class AlertSeverity:
     TOLERABLE = 'tolerable'
 
 
+class AlertKind:
+    """AUnit Alert kind Identifiers"""
+
+    ABORTION = 'abortion'
+
+
 # pylint: disable=too-few-public-methods
 class Alert(NamedTuple):
     """ABAP Unit Tests Framework ADT results Alert node"""
@@ -296,6 +302,14 @@ class Alert(NamedTuple):
         """Returns true if the alert represents a warning"""
 
         return self.severity == AlertSeverity.TOLERABLE
+
+    @property
+    def is_skip(self):
+        """Returns true if the alert a message about skipped test.
+           ABAP: cl_abap_unit_assert=>skip( 'Skipped because of a wrong system' ).
+        """
+
+        return self.severity == AlertSeverity.TOLERABLE and self.kind == AlertKind.ABORTION
 
 
 # pylint: disable=too-many-instance-attributes

--- a/test/unit/fixtures_adt_aunit.py
+++ b/test/unit/fixtures_adt_aunit.py
@@ -209,3 +209,34 @@ AUNIT_SYNTAX_ERROR_XML = '''<?xml version="1.0" encoding="utf-8"?>
   </program>
 </aunit:runResult>
 '''
+
+
+AUNIT_RESULTS_SKIPPED_XML = '''<?xml version="1.0" encoding="utf-8"?>
+<aunit:runResult xmlns:aunit="http://www.sap.com/adt/aunit">
+  <external>
+    <coverage xmlns:adtcore="http://www.sap.com/adt/core" adtcore:uri="/sap/bc/adt/runtime/traces/coverage/measurements/FOOBAR"/>
+  </external>
+  <program adtcore:uri="/sap/bc/adt/oo/classes/zcl_theking_manual_hardcore" adtcore:type="CLAS/OC" adtcore:name="ZCL_THEKING_MANUAL_HARDCORE" uriType="semantic" xmlns:adtcore="http://www.sap.com/adt/core">
+    <testClasses>
+      <testClass adtcore:uri="/sap/bc/adt/oo/classes/zcl_theking_manual_hardcore/includes/testclasses#type=CLAS%2FOCL;name=LTCL_TEST" adtcore:type="CLAS/OL" adtcore:name="LTCL_TEST" uriType="semantic" navigationUri="/sap/bc/adt/oo/classes/zcl_theking_manual_hardcore/includes/testclasses#type=CLAS%2FOCL;name=LTCL_TEST" durationCategory="short" riskLevel="harmless">
+        <testMethods>
+          <testMethod adtcore:uri="/sap/bc/adt/oo/classes/zcl_theking_manual_hardcore/includes/testclasses#type=CLAS%2FOLD;name=LTCL_TEST%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20DO_THE_FAIL" adtcore:type="CLAS/OLI" adtcore:name="DO_THE_FAIL" executionTime="0.033" uriType="semantic" navigationUri="/sap/bc/adt/oo/classes/zcl_theking_manual_hardcore/includes/testclasses#type=CLAS%2FOLD;name=LTCL_TEST%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20DO_THE_FAIL" unit="s">
+            <alerts>
+              <alert kind="abortion" severity="tolerable">
+                <title>Missing Prerequisites - This test should not be executed here.</title>
+                <details>
+                  <detail text="Test execution skipped due to missing prerequisites"/>
+                  <detail text="Test 'LTCL_TEST-&gt;DO_THE_FAIL' in Main Program 'ZCL_THEKING_MANUAL_HARDCORE===CP'."/>
+                </details>
+                <stack>
+                  <stackEntry adtcore:uri="/sap/bc/adt/oo/classes/zcl_theking_manual_hardcore/includes/testclasses#start=19,0" adtcore:type="CLAS/OCN/testclasses" adtcore:name="ZCL_THEKING_MANUAL_HARDCORE" adtcore:description="Include: &lt;ZCL_THEKING_MANUAL_HARDCORE===CCAU&gt; Line: &lt;19&gt; (DO_THE_FAIL)"/>
+                </stack>
+              </alert>
+            </alerts>
+          </testMethod>
+        </testMethods>
+      </testClass>
+    </testClasses>
+  </program>
+</aunit:runResult>
+'''


### PR DESCRIPTION
I was not sure how to convert ABAP ADT AUnit XML into JUnit.

I have decided to consider skipped only the tests with the kind ABORTION and the severity TOLERABLE - I consulted ABAP code of cl_abap_unit_assert=>skip( ).

Jenkins output:

    DO_THE_FAIL – ZCL_THEKING_MANUAL_HARDCORE=>LTCL_TEST

    Standard Output:
    Include: <ZCL_THEKING_MANUAL_HARDCORE===CCAU> Line: <19> (DO_THE_FAIL)

    Standard Error:
    Test execution skipped due to missing prerequisites
    Test 'LTCL_TEST->DO_THE_FAIL' in Main Program 'ZCL_THEKING_MANUAL_HARDCORE===CP'.

Closes #101