### PR TITLE
Fixing JaCoCo File

### DIFF
--- a/sap/cli/aunit.py
+++ b/sap/cli/aunit.py
@@ -528,9 +528,8 @@ def _print_source_file_jacoco(file_name, lines_data, console, indent, indent_lev
         covered_instructions = '1' if is_covered else '0'
         missed_instructions = '0' if is_covered else '1'
 
-        console.printout(
-            f'{line_level_indent}<line nr="{line_number}" mi="{missed_instructions}" ci="{covered_instructions}" mb="" cb=""/>'
-        )
+        console.printout(f'{line_level_indent}<line nr="{line_number}" mi="{missed_instructions}" '
+                         f'ci="{covered_instructions}" mb="" cb=""/>')
 
     console.printout(f'{file_level_indent}</sourcefile>')
 

--- a/sap/cli/aunit.py
+++ b/sap/cli/aunit.py
@@ -529,7 +529,7 @@ def _print_source_file_jacoco(file_name, lines_data, console, indent, indent_lev
         missed_instructions = '0' if is_covered else '1'
 
         console.printout(
-            f'{line_level_indent}<line nr="{line_number}" mi="{missed_instructions}" ci="{covered_instructions}"/>'
+            f'{line_level_indent}<line nr="{line_number}" mi="{missed_instructions}" ci="{covered_instructions}" mb="" cb=""/>'
         )
 
     console.printout(f'{file_level_indent}</sourcefile>')
@@ -553,7 +553,7 @@ def _print_class_jacoco(node, method_lines_mapping, console, indent, indent_leve
     console.printout(f'{class_level_indent}<class name="{node.name}" sourcefilename="{node.name}">')
     for method in node.nodes:
         line, _ = get_line_and_column(method.uri)
-        console.printout(f'{method_level_indent}<method name="{method.name}" line="{line}">')
+        console.printout(f'{method_level_indent}<method name="{method.name}" desc="" line="{line}">')
         _print_counters_jacoco(method, console, indent, indent_level + 2)
         console.printout(f'{method_level_indent}</method>')
 

--- a/test/unit/test_sap_cli_aunit.py
+++ b/test/unit/test_sap_cli_aunit.py
@@ -574,12 +574,12 @@ CL_FOO======CCAU:428
 <report name="ypackage">
    <package name="TEST_CHECK_LIST">
       <class name="FOO" sourcefilename="FOO">
-         <method name="METHOD_A" line="52">
+         <method name="METHOD_A" desc="" line="52">
             <counter type="BRANCH" missed="2" covered="3"/>
             <counter type="METHOD" missed="0" covered="1"/>
             <counter type="INSTRUCTION" missed="0" covered="5"/>
          </method>
-         <method name="METHOD_B" line="199">
+         <method name="METHOD_B" desc="" line="199">
             <counter type="BRANCH" missed="1" covered="1"/>
             <counter type="METHOD" missed="0" covered="1"/>
             <counter type="INSTRUCTION" missed="2" covered="6"/>
@@ -589,19 +589,19 @@ CL_FOO======CCAU:428
          <counter type="INSTRUCTION" missed="3" covered="60"/>
       </class>
       <sourcefile name="FOO">
-         <line nr="53" mi="0" ci="1"/>
-         <line nr="54" mi="0" ci="1"/>
-         <line nr="55" mi="0" ci="1"/>
-         <line nr="56" mi="0" ci="1"/>
-         <line nr="59" mi="0" ci="1"/>
-         <line nr="209" mi="0" ci="1"/>
-         <line nr="212" mi="0" ci="1"/>
-         <line nr="215" mi="0" ci="1"/>
-         <line nr="216" mi="0" ci="1"/>
-         <line nr="219" mi="0" ci="1"/>
-         <line nr="220" mi="0" ci="1"/>
-         <line nr="224" mi="1" ci="0"/>
-         <line nr="225" mi="1" ci="0"/>
+         <line nr="53" mi="0" ci="1" mb="" cb=""/>
+         <line nr="54" mi="0" ci="1" mb="" cb=""/>
+         <line nr="55" mi="0" ci="1" mb="" cb=""/>
+         <line nr="56" mi="0" ci="1" mb="" cb=""/>
+         <line nr="59" mi="0" ci="1" mb="" cb=""/>
+         <line nr="209" mi="0" ci="1" mb="" cb=""/>
+         <line nr="212" mi="0" ci="1" mb="" cb=""/>
+         <line nr="215" mi="0" ci="1" mb="" cb=""/>
+         <line nr="216" mi="0" ci="1" mb="" cb=""/>
+         <line nr="219" mi="0" ci="1" mb="" cb=""/>
+         <line nr="220" mi="0" ci="1" mb="" cb=""/>
+         <line nr="224" mi="1" ci="0" mb="" cb=""/>
+         <line nr="225" mi="1" ci="0" mb="" cb=""/>
       </sourcefile>
       <class name="BAR" sourcefilename="BAR">
          <counter type="BRANCH" missed="0" covered="0"/>


### PR DESCRIPTION
Given I collect a class coverage and store it as jacoco format:
`sapcli aunit run class xxx --coverage-output jacoco`

When I publish this file in Jenkins:
`recordCoverage(id: 'abap-coverage', name: 'ABAP Coverage', sourceCodeEncoding: 'UTF-8', tools: [[parser: 'JACOCO', pattern: '**/abapCodeCoverage-*.xml']])`

Then, it fails:
`java.util.NoSuchElementException: Could not obtain attribute 'desc' from element '<method line='29' name='GET_INSTANCE'>'`
`java.util.NoSuchElementException: Could not obtain attribute 'cb' from element '<line nr='30' ci='1' mi='0'>'`
`java.util.NoSuchElementException: Could not obtain attribute 'mb' from element '<line nr='30' ci='1' mi='0' cb=''>'`

There were some missing attributes in the JaCoCo generated file. I added them empty to fix the syntax error. 
In a future pull request, I will study how to implement these fields properly. 

JaCoCo fields:
```xml
<!-- representation of a method -->
<!ELEMENT method (counter*)>
  <!-- method name -->
  <!ATTLIST method name CDATA #REQUIRED>
  <!-- method descriptor -->
  <!ATTLIST method desc CDATA #REQUIRED>
  <!-- first source line number of this method -->
  <!ATTLIST method line CDATA #IMPLIED>
```

```xml
<!-- representation of a source line -->
<!ELEMENT line EMPTY>
  <!-- line number -->
  <!ATTLIST line nr CDATA #REQUIRED>
  <!-- number of missed instructions -->
  <!ATTLIST line mi CDATA #IMPLIED>
  <!-- number of covered instructions -->
  <!ATTLIST line ci CDATA #IMPLIED>
  <!-- number of missed branches -->
  <!ATTLIST line mb CDATA #IMPLIED>
  <!-- number of covered branches -->
  <!ATTLIST line cb CDATA #IMPLIED>
```

Source:
[report.txt](https://github.com/jfilak/sapcli/files/11727782/report.txt)
