### PR TITLE
datapreview: special characters processing in dataPreview:data xml node fixed

### DIFF
--- a/test/unit/fixtures_adt_datapreview.py
+++ b/test/unit/fixtures_adt_datapreview.py
@@ -21,7 +21,7 @@ ADT_XML_FREESTYLE_TABLE_T000='''<?xml version="1.0" encoding="UTF-8"?>
   <dataPreview:columns>
     <dataPreview:metadata dataPreview:name="ORT01" dataPreview:type="C" dataPreview:description="ORT01" dataPreview:keyAttribute="false" dataPreview:colType="" dataPreview:isKeyFigure="false"/>
     <dataPreview:dataSet>
-      <dataPreview:data>Walldorf</dataPreview:data>
+      <dataPreview:data>Walldorf &amp; Brno &lt; London</dataPreview:data>
       <dataPreview:data>Walldorf</dataPreview:data>
     </dataPreview:dataSet>
   </dataPreview:columns>

--- a/test/unit/test_sap_adt_datapreview.py
+++ b/test/unit/test_sap_adt_datapreview.py
@@ -36,7 +36,7 @@ class TestFreeStyleTableParseResults(unittest.TestCase):
                                     'MANDT': '000',
                                     'MTEXT': 'SAP SE',
                                     'MWAER': 'EUR',
-                                    'ORT01': 'Walldorf'},
+                                    'ORT01': 'Walldorf & Brno < London'},
                                    {'ADRNR': '',
                                     'CCCATEGORY': 'C',
                                     'CCCOPYLOCK': '',


### PR DESCRIPTION
In case the string contained special characters, like & (ampersand), the XML parser splitted the string by ampersand and it returned only string behind the last ampersand. Now, the dataPreview:data content is wrapped to <![CDATA[...]]> that ensures that the content is taken as a unit