### PR TITLE
tree-wide: add support for reading Authorization Fields

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -27,4 +27,5 @@
 25. [table](commands/table.md) - ABAP DDIC transparent tables
 26. [badi](commands/badi.md) - New style (Enhancements) BAdI operations
 27. [featuretoggle](commands/featuretoggles.md) - Feature Toggles
-27. [abap](commands/abap.md) - ABAP utilities like run or find
+28. [authorizations](commands/authorizations.md) - Authorization Fields, Objects, Transactions, and Defaults
+29. [abap](commands/abap.md) - ABAP utilities like run or find

--- a/doc/commands/authorizations.md
+++ b/doc/commands/authorizations.md
@@ -1,0 +1,90 @@
+# Authorization Objects
+
+- [Authorization Field](#authorization-field)
+    - [read](#read)
+    - [whereused](#whereused)
+    - [activate](#activate)
+
+## Authorization Field
+
+Authorization fields are ABAP dictionary objects used in authorization checks to control access to business data and transactions.
+
+### read
+
+Read and display an Authorization Field and its properties.
+
+```bash
+sapcli authorizationfield read AUTHORIZATION_FIELD_NAME [--format=HUMAN|ABAP]
+```
+
+* _AUTHORIZATION\_FIELD\_NAME_ specifying the name of the authorization field (e.g., BEGRU, ACTVT)
+* _--format_ output format for the authorization field details **(optional, default: HUMAN)**
+  - `HUMAN` - human-readable format with labeled fields
+  - `ABAP` - ABAP-compatible format (not yet implemented)
+
+**Example:**
+
+```bash
+sapcli authorizationfield read BEGRU
+```
+
+**Output:**
+
+```text
+Authorization Field: BEGRU
+Description: Authorization Group
+Package: S_BUPA_GENERAL
+Responsible: KNOETIG
+Master Language: DE
+
+Content:
+  Field Name: BEGRU
+  Roll Name: BEGRU
+  Check Table: 
+  Exit FB: 
+  Domain Name: BEGRU
+  Output Length: 000004
+  Conversion Exit: 
+  Search: false
+  Object Exit: false
+  Org Level Info: Field is not defined as Organizational level.
+  Collective Search Help: false
+  Collective Search Help Name: 
+  Collective Search Help Description: 
+```
+
+### whereused
+
+Find objects that reference the given authorization field.
+
+```bash
+sapcli authorizationfield whereused AUTHORIZATION_FIELD_NAME
+```
+
+* _AUTHORIZATION\_FIELD\_NAME_ specifying the name of the authorization field
+
+**Example:**
+
+```bash
+sapcli authorizationfield whereused BEGRU
+```
+
+### activate
+
+Activate the given authorization field.
+
+```bash
+sapcli authorizationfield activate AUTHORIZATION_FIELD_NAME [AUTHORIZATION_FIELD_NAME ...] [--ignore-errors] [--warning-errors]
+```
+
+* _AUTHORIZATION\_FIELD\_NAME_ one or more authorization field names to activate
+* _--ignore-errors_ do not stop activation in case of errors **(optional)**
+* _--warning-errors_ treat activation warnings as errors **(optional)**
+
+**Example:**
+
+```bash
+sapcli authorizationfield activate BEGRU ACTVT
+```
+
+**Note:** Create, write, and delete operations are disabled because these operations have not been tested.

--- a/sap/adt/__init__.py
+++ b/sap/adt/__init__.py
@@ -15,4 +15,5 @@ from sap.adt.table import Table  # noqa: F401
 from sap.adt.enhancement_implementation import EnhancementImplementation  # noqa: F401
 from sap.adt.structure import Structure  # noqa: F401
 from sap.adt.dataelement import DataElement  # noqa: F401
+from sap.adt.authorization_field import AuthorizationField  # noqa: F401
 from sap.adt.whereused import where_used, get_scope, get_where_used  # noqa: F401

--- a/sap/adt/authorization_field.py
+++ b/sap/adt/authorization_field.py
@@ -1,0 +1,54 @@
+"""ABAP Authorization Field ADT functionality module"""
+
+from sap.adt.objects import ADTObject, ADTObjectType, XMLNamespace, XMLNS_ADTCORE
+# pylint: disable=unused-import
+from sap.adt.annotations import (
+    OrderedClassMembers,
+    xml_text_node_property,
+    XmlNodeProperty,
+)
+
+XMLNS_AUTH = XMLNamespace('auth', 'http://www.sap.com/iam/auth')
+
+
+# pylint: disable=too-few-public-methods
+class AuthorizationFieldContent(metaclass=OrderedClassMembers):
+    """ADT Authorization Field content data collector"""
+
+    field_name = xml_text_node_property('auth:fieldName')
+    roll_name = xml_text_node_property('auth:rollName')
+    check_table = xml_text_node_property('auth:checkTable')
+    exit_fb = xml_text_node_property('auth:exitFB')
+    abap_language_version = xml_text_node_property('auth:abap_language_version')
+    search = xml_text_node_property('auth:search')
+    objexit = xml_text_node_property('auth:objexit')
+    domname = xml_text_node_property('auth:domname')
+    outputlen = xml_text_node_property('auth:outputlen')
+    convexit = xml_text_node_property('auth:convexit')
+    orglvlinfo = xml_text_node_property('auth:orglvlinfo')
+    col_searchhelp = xml_text_node_property('auth:col_searchhelp')
+    col_searchhelp_name = xml_text_node_property('auth:col_searchhelp_name')
+    col_searchhelp_descr = xml_text_node_property('auth:col_searchhelp_descr')
+
+
+class AuthorizationField(ADTObject):
+    """ABAP Authorization Field"""
+
+    OBJTYPE = ADTObjectType(
+        'AUTH',
+        'aps/iam/auth',
+        XMLNamespace('auth', 'http://www.sap.com/iam/auth', parents=[XMLNS_ADTCORE]),
+        'application/vnd.sap.adt.blues.v1+xml',
+        None,
+        'auth',
+        editor_factory=None
+    )
+
+    content = XmlNodeProperty('auth:content')
+
+    def __init__(self, connection, name, package=None, metadata=None):
+        super().__init__(connection, name, metadata)
+
+        if package is not None:
+            self._metadata.package_reference.name = package
+        self.content = AuthorizationFieldContent()

--- a/sap/cli/__init__.py
+++ b/sap/cli/__init__.py
@@ -53,6 +53,7 @@ class CommandsCache:
         import sap.cli.badi
         import sap.cli.structure
         import sap.cli.dataelement
+        import sap.cli.authorizationfield
         import sap.cli.abap
         import sap.cli.config
 
@@ -80,6 +81,7 @@ class CommandsCache:
                 (adt_connection_from_args, sap.cli.table.CommandGroup()),
                 (adt_connection_from_args, sap.cli.structure.CommandGroup()),
                 (adt_connection_from_args, sap.cli.dataelement.CommandGroup()),
+                (adt_connection_from_args, sap.cli.authorizationfield.CommandGroup()),
                 (adt_connection_from_args, sap.cli.checkin.CommandGroup()),
                 (adt_connection_from_args, sap.cli.badi.CommandGroup()),
                 (adt_connection_from_args, sap.cli.featuretoggle.CommandGroup()),

--- a/sap/cli/authorizationfield.py
+++ b/sap/cli/authorizationfield.py
@@ -1,0 +1,74 @@
+"""Command line interface for Authorization Field ADT object."""
+
+import sap.adt
+import sap.cli.object
+from sap.errors import SAPCliError
+
+
+class CommandGroup(sap.cli.object.CommandGroupObjectMaster):
+    """Adapter converting command line parameters to sap.adt.AuthorizationField calls."""
+
+    def __init__(self):
+        super().__init__('authorizationfield')
+        self.define()
+
+    def instance(self, connection, name, args, metadata=None):
+        """Creates an instance of the Authorization Field ADT object based on the provided parameters."""
+
+        return sap.adt.AuthorizationField(connection, name.upper(), metadata=metadata)
+
+    def define_read(self, commands):
+        """Add the argument --format=ABAP|HUMAN to the read command to allow users to choose the output format."""
+
+        read_cmd = super().define_read(commands)
+        read_cmd.append_argument(
+            '--format',
+            choices=['ABAP', 'HUMAN'],
+            default='HUMAN',
+            help='Output format for the Authorization Field details'
+        )
+        return read_cmd
+
+    def create_object(self, connection, args):
+        """Create is not supported for Authorization Fields"""
+        raise SAPCliError('Create Authorization Field is not implemented yet.')
+
+    def delete_object(self, connection, args):
+        """Delete is not supported for Authorization Fields"""
+        raise SAPCliError('Delete Authorization Field is not implemented yet.')
+
+    def write_object_text(self, connection, args):
+        """Write is not supported for Authorization Fields"""
+        raise SAPCliError('Write Authorization Field is not implemented yet.')
+
+    def read_object_text(self, connection, args):
+        """Retrieves the Authorization Field and prints its details"""
+
+        console = args.console_factory()
+        obj = self.instance(connection, args.name, args)
+        obj.fetch()
+
+        if args.format == 'ABAP':
+            raise SAPCliError('ABAP format output is not implemented yet. Please use --format=HUMAN for now.')
+
+        # Print the details of the Authorization Field in a human-readable format
+        console.printout(f'Authorization Field: {obj.name}')
+        console.printout(f'Description: {obj.description}')
+        console.printout(f'Package: {obj.reference.name}')
+        console.printout(f'Responsible: {obj.responsible}')
+        console.printout(f'Master Language: {obj.master_language}')
+        console.printout('')
+        console.printout('Content:')
+        console.printout(f'  Field Name: {obj.content.field_name or ""}')
+        console.printout(f'  Roll Name: {obj.content.roll_name or ""}')
+        console.printout(f'  Check Table: {obj.content.check_table or ""}')
+        console.printout(f'  Exit FB: {obj.content.exit_fb or ""}')
+        console.printout(f'  Domain Name: {obj.content.domname or ""}')
+        console.printout(f'  Output Length: {obj.content.outputlen or ""}')
+        console.printout(f'  Conversion Exit: {obj.content.convexit or ""}')
+        console.printout(f'  Search: {obj.content.search or ""}')
+        console.printout(f'  Object Exit: {obj.content.objexit or ""}')
+        console.printout(f'  Org Level Info: {obj.content.orglvlinfo or ""}')
+        console.printout(f'  Collective Search Help: {obj.content.col_searchhelp or ""}')
+        console.printout(f'  Collective Search Help Name: {obj.content.col_searchhelp_name or ""}')
+        console.printout(f'  Collective Search Help Description: {obj.content.col_searchhelp_descr or ""}')

--- a/test/unit/fixtures_sap_adt_authorization_field.py
+++ b/test/unit/fixtures_sap_adt_authorization_field.py
@@ -1,0 +1,37 @@
+"""Test fixtures for Authorization Field"""
+
+AUTHORIZATION_FIELD_NAME = 'BEGRU'
+
+AUTHORIZATION_FIELD_ADT_GET_RESPONSE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<auth:auth xmlns:auth="http://www.sap.com/iam/auth" adtcore:responsible="KNOETIG" adtcore:masterLanguage="DE" adtcore:masterSystem="YI3" adtcore:abapLanguageVersion="standard" adtcore:name="BEGRU" adtcore:type="AUTH" adtcore:changedAt="1971-04-01T00:00:00Z" adtcore:createdBy="KNOETIG" adtcore:description="Authorization Group" adtcore:descriptionTextLimit="60" adtcore:language="EN" xmlns:adtcore="http://www.sap.com/adt/core">
+  <atom:link xmlns:atom="http://www.w3.org/2005/Atom" href="versions" rel="http://www.sap.com/adt/relations/versions" title="Historic versions"/>
+  <atom:link xmlns:atom="http://www.w3.org/2005/Atom" href="/sap/bc/adt/repository/informationsystem/abaplanguageversions?uri=%2Fsap%2Fbc%2Fadt%2Faps%2Fiam%2Fauth%2Fbegru" rel="http://www.sap.com/adt/relations/informationsystem/abaplanguageversions" type="application/vnd.sap.adt.nameditems.v1+xml" title="Allowed ABAP language versions"/>
+  <atom:link xmlns:atom="http://www.w3.org/2005/Atom" href="/sap/bc/adt/vit/wb/object_type/auth/object_name/BEGRU" rel="self" type="application/vnd.sap.sapgui" title="Representation in SAP GUI"/>
+  <atom:link xmlns:atom="http://www.w3.org/2005/Atom" href="./begru" rel="http://www.sap.com/adt/relations/source" type="text/html" title="Landing Page (HTML)"/>
+  <adtcore:packageRef adtcore:uri="/sap/bc/adt/packages/s_bupa_general" adtcore:type="DEVC/K" adtcore:name="S_BUPA_GENERAL" adtcore:description="SAP Business Partner: Basic Components"/>
+  <auth:content>
+    <auth:fieldName>BEGRU</auth:fieldName>
+    <auth:rollName>BEGRU</auth:rollName>
+    <auth:checkTable/>
+    <auth:exitFB/>
+    <auth:abap_language_version/>
+    <auth:search>false</auth:search>
+    <auth:objexit>false</auth:objexit>
+    <auth:domname>BEGRU</auth:domname>
+    <auth:outputlen>000004</auth:outputlen>
+    <auth:convexit/>
+    <auth:orglvlinfo>Field is not defined as Organizational level.</auth:orglvlinfo>
+    <auth:col_searchhelp>false</auth:col_searchhelp>
+    <auth:col_searchhelp_name/>
+    <auth:col_searchhelp_descr/>
+    <auth:objectVisibility>
+      <auth:isSearchHelpTypeVisible>true</auth:isSearchHelpTypeVisible>
+      <auth:isExitModuleVisible>true</auth:isExitModuleVisible>
+      <auth:isCreateAuthObjectVisible>true</auth:isCreateAuthObjectVisible>
+      <auth:isAssignToAuthObjectVisible>true</auth:isAssignToAuthObjectVisible>
+      <auth:isCreateRestrictionFieldVisible>false</auth:isCreateRestrictionFieldVisible>
+      <auth:isAbapDictionaryVisible>true</auth:isAbapDictionaryVisible>
+      <auth:isAddSearchHelpVisible>true</auth:isAddSearchHelpVisible>
+    </auth:objectVisibility>
+  </auth:content>
+</auth:auth>"""

--- a/test/unit/test_sap_adt_authorization_field.py
+++ b/test/unit/test_sap_adt_authorization_field.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import unittest
+import sap.adt
+import sap.adt.authorization_field
+
+from mock import Connection, Response
+from fixtures_sap_adt_authorization_field import AUTHORIZATION_FIELD_NAME, AUTHORIZATION_FIELD_ADT_GET_RESPONSE_XML
+
+
+class TestADTAuthorizationField(unittest.TestCase):
+
+    def test_authorization_field_fetch(self):
+        connection = Connection([Response(text=AUTHORIZATION_FIELD_ADT_GET_RESPONSE_XML, status_code=200, headers={})])
+
+        auth_field = sap.adt.AuthorizationField(connection, AUTHORIZATION_FIELD_NAME)
+        auth_field.fetch()
+
+        self.assertEqual(auth_field.name, AUTHORIZATION_FIELD_NAME)
+        self.assertEqual(auth_field.master_language, 'DE')
+        self.assertEqual(auth_field.description, 'Authorization Group')
+        self.assertEqual(auth_field.content.field_name, 'BEGRU')
+        self.assertEqual(auth_field.content.roll_name, 'BEGRU')
+        self.assertEqual(auth_field.content.search, 'false')
+        self.assertEqual(auth_field.content.objexit, 'false')
+        self.assertEqual(auth_field.content.domname, 'BEGRU')
+        self.assertEqual(auth_field.content.outputlen, '000004')
+        self.assertEqual(auth_field.content.orglvlinfo, 'Field is not defined as Organizational level.')
+        self.assertEqual(auth_field.content.col_searchhelp, 'false')
+
+    def test_authorization_field_with_package(self):
+        """Test that package parameter is correctly set"""
+        connection = Connection()
+
+        auth_field = sap.adt.AuthorizationField(connection, AUTHORIZATION_FIELD_NAME, package='TEST_PACKAGE')
+
+        self.assertEqual(auth_field.name, AUTHORIZATION_FIELD_NAME)
+        self.assertEqual(auth_field.reference.name, 'TEST_PACKAGE')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_sap_cli_authorizationfield.py
+++ b/test/unit/test_sap_cli_authorizationfield.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import sap.cli.authorizationfield
+from sap.errors import SAPCliError
+
+from mock import (
+    BufferConsole,
+    Connection,
+    Response,
+)
+
+from infra import generate_parse_args
+from fixtures_sap_adt_authorization_field import (
+    AUTHORIZATION_FIELD_NAME,
+    AUTHORIZATION_FIELD_ADT_GET_RESPONSE_XML,
+)
+
+
+class TestAuthorizationFieldRead(unittest.TestCase):
+
+    def authorization_field_read_cmd(self, *args, **kwargs):
+        # Lazy initialization to avoid module-level CommandGroup instantiation
+        parser = generate_parse_args(sap.cli.authorizationfield.CommandGroup())
+        return parser('read', *args, **kwargs)
+
+    def test_read(self):
+        connection = Connection([
+            Response(text=AUTHORIZATION_FIELD_ADT_GET_RESPONSE_XML, status_code=200, headers={})
+        ])
+
+        console = BufferConsole()
+        the_cmd = self.authorization_field_read_cmd(AUTHORIZATION_FIELD_NAME)
+        the_cmd.console_factory = lambda: console
+        the_cmd.execute(connection, the_cmd)
+
+        expected_output = 'Authorization Field: BEGRU\nDescription: Authorization Group\nPackage: S_BUPA_GENERAL\nResponsible: KNOETIG\nMaster Language: DE\n\nContent:\n  Field Name: BEGRU\n  Roll Name: BEGRU\n  Check Table: \n  Exit FB: \n  Domain Name: BEGRU\n  Output Length: 000004\n  Conversion Exit: \n  Search: false\n  Object Exit: false\n  Org Level Info: Field is not defined as Organizational level.\n  Collective Search Help: false\n  Collective Search Help Name: \n  Collective Search Help Description: \n'
+
+        self.assertEqual(console.capout, expected_output)
+
+    def test_read_uppercase_name(self):
+        """Test that lowercase input is converted to uppercase"""
+        connection = Connection([
+            Response(text=AUTHORIZATION_FIELD_ADT_GET_RESPONSE_XML, status_code=200, headers={})
+        ])
+
+        console = BufferConsole()
+        the_cmd = self.authorization_field_read_cmd('begru')  # lowercase
+        the_cmd.console_factory = lambda: console
+        the_cmd.execute(connection, the_cmd)
+
+        # Should still work and show BEGRU (uppercase) in output
+        self.assertIn('Authorization Field: BEGRU', console.capout)
+
+    def test_read_abap_format_not_implemented(self):
+        """Test that ABAP format raises error"""
+        connection = Connection([
+            Response(text=AUTHORIZATION_FIELD_ADT_GET_RESPONSE_XML, status_code=200, headers={})
+        ])
+
+        console = BufferConsole()
+        the_cmd = self.authorization_field_read_cmd(AUTHORIZATION_FIELD_NAME, '--format=ABAP')
+        the_cmd.console_factory = lambda: console
+
+        with self.assertRaises(SAPCliError) as cm:
+            the_cmd.execute(connection, the_cmd)
+
+        self.assertIn('ABAP format output is not implemented yet', str(cm.exception))
+
+
+class TestAuthorizationFieldUnsupportedOperations(unittest.TestCase):
+    """Test that unsupported operations raise appropriate errors"""
+
+    def test_create_not_supported(self):
+        """Test that create operation raises error"""
+        connection = Connection()
+        cmd_group = sap.cli.authorizationfield.CommandGroup()
+
+        with self.assertRaises(SAPCliError) as cm:
+            cmd_group.create_object(connection, None)
+
+        self.assertIn('Create Authorization Field is not implemented yet', str(cm.exception))
+
+    def test_delete_not_supported(self):
+        """Test that delete operation raises error"""
+        connection = Connection()
+        cmd_group = sap.cli.authorizationfield.CommandGroup()
+
+        with self.assertRaises(SAPCliError) as cm:
+            cmd_group.delete_object(connection, None)
+
+        self.assertIn('Delete Authorization Field is not implemented yet', str(cm.exception))
+
+    def test_write_not_supported(self):
+        """Test that write operation raises error"""
+        connection = Connection()
+        cmd_group = sap.cli.authorizationfield.CommandGroup()
+
+        with self.assertRaises(SAPCliError) as cm:
+            cmd_group.write_object_text(connection, None)
+
+        self.assertIn('Write Authorization Field is not implemented yet', str(cm.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Basic support to dump authorization field data into command line.

The command line does not support create and delete because I had not the nerves to test if it really works or not. If you are brave and have more time, test it and enable it - do not for get to update the automated tests.