### PR TITLE
Refactor ADT HTTP client

### DIFF
--- a/sap/adt/core.py
+++ b/sap/adt/core.py
@@ -3,17 +3,12 @@
 import xml.sax
 from xml.sax.handler import ContentHandler
 
-import requests
-from requests.auth import HTTPBasicAuth
-
-from sap import get_logger, config_get
-from sap.rest.connection import setup_keepalive
+import sap.http
+from sap import get_logger
 from sap.adt.errors import new_adt_error_from_xml, ADTConnectionError
-from sap.rest.errors import (
+from sap.http import (
     HTTPRequestError,
     UnexpectedResponseContent,
-    UnauthorizedError,
-    TimedOutRequestError,
 )
 
 
@@ -85,6 +80,20 @@ def _get_collection_accepts(discovery_xml):
     return xml_handler.result
 
 
+def _adt_http_error_handler(client, req, res):  # pylint: disable=unused-argument
+
+    if res.headers['content-type'] == 'application/xml':
+        error = new_adt_error_from_xml(res.text)
+
+        if error is not None:
+            raise error
+
+
+def _adt_http_connection_error_handler(client, ex):
+    msg = str(ex)
+    raise ADTConnectionError(client.host, client.port, client.ssl, msg) from ex
+
+
 # pylint: disable=too-many-instance-attributes
 class Connection:
     """ADT Connection for HTTP communication built on top Python requests.
@@ -104,114 +113,52 @@ class Connection:
             - ssl_server_cert: optional path to a custom CA certificate file
         """
 
-        setup_keepalive()
+        sap.http.setup_keepalive()
 
-        if ssl:
-            protocol = 'https'
-            if port is None:
-                port = '443'
-        else:
-            protocol = 'http'
-            if port is None:
-                port = '80'
-        self._ssl_verify = verify
-        self._ssl_server_cert = ssl_server_cert
+        self._base_adt_path = 'sap/bc/adt'
 
-        self._host = host
-        self._port = port
-        self._ssl = ssl
-        self._adt_uri = 'sap/bc/adt'
-        self._base_url = f'{protocol}://{host}:{port}/{self._adt_uri}'
-        self._query_args = f'sap-client={client}&saml2=disabled'
-        self._user = user
-        self._auth = HTTPBasicAuth(user, password)
+        self._http_client = sap.http.HTTPClient(
+            ssl=ssl,
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            saml2=False,
+            client=client,
+            verify=verify,
+            ssl_server_cert=ssl_server_cert,
+            # This must be the default login path because newer ABAP systems
+            # did not return cookies and CSRF token with the old default login
+            # path (GET /sap/bc/adt/discovery) and thus did not work with
+            # the default login method of HTTPClient.
+            login_path=f'{self._base_adt_path}/core/discovery',
+            login_method='GET'
+        )
+
+        self._http_client.add_error_handler(_adt_http_error_handler)
+        self._http_client.set_connection_error_handler(_adt_http_connection_error_handler)
+
         self._session = None
         self._collection_types = None
-        self._timeout = config_get('http_timeout')
 
     @property
     def user(self):
         """Connected user"""
 
-        return self._user
+        return self._http_client.user
 
     @property
     def uri(self):
         """ADT path for building URLs (e.g. sap/bc/adt)"""
 
-        return self._adt_uri
+        return self._base_adt_path
 
     def _build_adt_url(self, adt_uri):
         """Creates complete URL from a fragment of ADT URI
            where the fragment usually refers to an ADT object
         """
 
-        return f'{self._base_url}/{adt_uri}?{self._query_args}'
-
-    def _handle_http_error(self, req, res):
-        """Raise the correct exception based on response content."""
-
-        if res.headers['content-type'] == 'application/xml':
-            error = new_adt_error_from_xml(res.text)
-
-            if error is not None:
-                raise error
-
-        # else - unformatted text
-        if res.status_code == 401:
-            raise UnauthorizedError(req, res, self._user)
-
-        raise HTTPRequestError(req, res)
-
-    def _retrieve(self, session, method, url, params=None, headers=None, body=None):
-        """A helper method for easier testing."""
-
-        req = requests.Request(method.upper(), url, params=params, data=body, headers=headers)
-        req = session.prepare_request(req)
-
-        mod_log().info('Executing %s %s\nHeaders:%s\n++++\n%s\n++++', method, url, str(headers), str(body))
-
-        try:
-            res = session.send(req, timeout=self._timeout)
-        except requests.exceptions.ConnectTimeout as ex:
-            raise TimedOutRequestError(req, self._timeout) from ex
-        except requests.exceptions.ReadTimeout as ex:
-            raise TimedOutRequestError(req, self._timeout) from ex
-        except requests.exceptions.ConnectionError as ex:
-            msg = str(ex)
-            raise ADTConnectionError(self._host, self._port, self._ssl, msg) from ex
-
-        mod_log().debug('Response %s %s:\nHeaders:%s\n++++\n%s\n++++', method, url, str(res.headers), res.text)
-
-        return (req, res)
-
-    def _execute_with_session(self, session, method, url, params=None, headers=None, body=None):
-        """Executes the given URL using the given method in
-           the common HTTP session.
-        """
-
-        req, res = self._retrieve(session, method, url, params=params, headers=headers, body=body)
-
-        if res.status_code == 403 and (not headers or headers.get('x-csrf-token', '') != 'Fetch'):
-            mod_log().debug('Re-Fetching CSRF token')
-
-            del session.headers['x-csrf-token']
-
-            response = self._execute_with_session(
-                session,
-                'GET',
-                self._build_adt_url('discovery'),
-                headers={'x-csrf-token': 'Fetch'}
-            )
-
-            session.headers['x-csrf-token'] = response.headers['x-csrf-token']
-
-            req, res = self._retrieve(session, method, url, params=params, headers=headers, body=body)
-
-        if res.status_code >= 400:
-            self._handle_http_error(req, res)
-
-        return res
+        return f'{self._base_adt_path}/{adt_uri}'
 
     def _get_session(self):
         """Returns the working HTTP session.
@@ -220,38 +167,28 @@ class Connection:
         """
 
         if self._session is None:
-            self._session = requests.Session()
-            self._session.auth = self._auth
-            # requests.session.verify is either boolean or path to CA to use!
-            if self._ssl_server_cert:
-                self._session.verify = self._ssl_server_cert
-                mod_log().info('Using custom SSL Server cert path: %s', self._session.verify)
-            elif self._ssl_verify is False:
-                import urllib3
-                urllib3.disable_warnings()
-                mod_log().info('SSL Server cert will not be verified: SAP_SSL_VERIFY = no')
-                self._session.verify = False
-
-            discovery_headers = {'x-csrf-token': 'Fetch'}
-            csrf_token = None
-            url = self._build_adt_url('core/discovery')
-
             try:
-                response = self._execute_with_session(self._session, 'GET', url, headers=discovery_headers)
-                discovery_headers = {}
-                csrf_token = response.headers['x-csrf-token']
+                self._session, _ = self._http_client.build_session()
             except HTTPRequestError as ex:
+                # Because some systems do to not have /sap/bc/adt/core/discovery endpoint.
                 if ex.response.status_code != 404:
                     raise ex
 
-            url = self._build_adt_url('discovery')
-            response = self._execute_with_session(self._session, 'GET', url, headers=discovery_headers)
+            # Reset login path to discovery because some system do no have /sap/bc/adt/core/discovery
+            # endpoint but do have /sap/bc/adt/discovery.
+            # Also if we lose session (403) we must use the /sap/bc/adt/discovery too. I do not know why!
+            self._http_client.login_path = f'{self._base_adt_path}/discovery'
+
+            response = None
+            if self._session is None:
+                # It means 404 on /sap/bc/adt/core/discovery endpoint,
+                # try to build session with /sap/bc/adt/discovery endpoint
+                self._session, response = self._http_client.build_session()
+
+            if response is None:
+                response = self._http_client.execute_with_session(self._session, 'GET', self._build_adt_url('discovery'))
+
             self._collection_types = _get_collection_accepts(response.text)
-
-            if csrf_token is None:
-                csrf_token = response.headers['x-csrf-token']
-
-            self._session.headers.update({'x-csrf-token': csrf_token})
 
         return self._session
 
@@ -279,7 +216,7 @@ class Connection:
         if not headers:
             headers = None
 
-        resp = self._execute_with_session(session, method, url, params=params, headers=headers, body=body)
+        resp = self._http_client.execute_with_session(session, method, url, params=params, headers=headers, body=body)
 
         if accept:
             resp_content_type = resp.headers['Content-Type']
@@ -313,7 +250,7 @@ class Connection:
     def get_collection_types(self, basepath, default_mimetype):
         """Returns the accepted object XML format - mime type"""
 
-        uri = f'/{self._adt_uri}/{basepath}'
+        uri = f'/{self._base_adt_path}/{basepath}'
         try:
             return self.collection_types[uri]
         except KeyError:

--- a/sap/cli/_entry.py
+++ b/sap/cli/_entry.py
@@ -15,7 +15,7 @@ import sap.cli
 import sap.adt
 import sap.rfc
 from sap.config import ConfigFile
-from sap.rest.errors import TimedOutRequestError as RestTimedOutRequestError
+from sap.http import TimedOutRequestError as HttpTimedOutRequestError
 from sap.odata.errors import TimedOutRequestError as ODataTimedOutRequestError
 
 # pylint: disable=invalid-name
@@ -183,7 +183,7 @@ def main(argv=None):
         retval = args.execute(connection, args)
     except KeyboardInterrupt:
         log.error('Program interrupted!')
-    except (RestTimedOutRequestError, ODataTimedOutRequestError) as ex:
+    except (HttpTimedOutRequestError, ODataTimedOutRequestError) as ex:
         print(f'Exception ({type(ex).__name__}):', file=sys.stderr)
         print(' ', str(ex), file=sys.stderr)
         print('  You can increase the timeout with the environment variable SAPCLI_HTTP_TIMEOUT (in seconds).', file=sys.stderr)

--- a/sap/cli/gcts.py
+++ b/sap/cli/gcts.py
@@ -29,7 +29,7 @@ from sap.rest.gcts.activities import (
     is_clone_activity_success,
 )
 from sap.errors import OperationTimeoutError
-from sap.rest.errors import HTTPRequestError
+from sap.http import HTTPRequestError
 from sap.cli.gcts_task import CommandGroup as TaskCommandGroup
 from sap.cli.gcts_utils import (
     dump_gcts_messages,

--- a/sap/cli/package.py
+++ b/sap/cli/package.py
@@ -9,6 +9,7 @@ import sap.adt.checks
 import sap.adt.objects
 import sap.adt.wb
 import sap.cli.wb
+import sap.http
 from sap.adt.errors import ExceptionResourceAlreadyExists, ExceptionResourceNotFound
 from sap.adt.objects import ADTObjectReference, ADTObjectReferences
 
@@ -259,7 +260,7 @@ def _run_reporters_for_objects(connection, reporters, package_objects):
         try:
             reports = sap.adt.checks.run(connection, reporter, check_objects)
             checks += 1
-        except sap.rest.errors.HTTPRequestError as ex:
+        except sap.http.HTTPRequestError as ex:
             mod_log().info('Reporter %s\n%s', reporter.name, str(ex))
         else:
             results.extend(reports)

--- a/sap/http/__init__.py
+++ b/sap/http/__init__.py
@@ -1,0 +1,59 @@
+"""HTTP connection helpers and shared error types"""
+
+import socket
+
+from urllib3.connection import HTTPConnection
+
+from sap import get_logger
+
+
+KEEPALIVE_CONFIGURED = False
+
+
+def mod_log():
+    """HTTP Module logger"""
+
+    return get_logger()
+
+
+def setup_keepalive():
+    """Make sure we send keepalive TCP packets"""
+
+    # pylint: disable=global-statement
+    global KEEPALIVE_CONFIGURED
+
+    if KEEPALIVE_CONFIGURED:
+        mod_log().debug("KeepAlive already configured")
+        return
+
+    KEEPALIVE_CONFIGURED = True
+
+    mod_log().debug("Updating urllib3.connection.HTTPConnection.default_socket_options with KeepAlive packets")
+
+    # Special thanks to: https://www.finbourne.com/blog/the-mysterious-hanging-client-tcp-keep-alives
+    # This may cause problems in Windows!
+    if "TCP_KEEPIDLE" in dir(socket):
+        # pylint: disable=no-member
+        HTTPConnection.default_socket_options = HTTPConnection.default_socket_options + [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+            (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
+        ]
+
+
+# Re-export submodule contents for backward compatibility
+# pylint: disable=wrong-import-position
+
+from sap.http.errors import (  # noqa: E402, F401  # pylint: disable=unused-import
+    UnexpectedResponseContent,
+    HTTPRequestError,
+    UnauthorizedError,
+    TimedOutRequestError,
+)
+
+from sap.http.client import (  # noqa: E402, F401  # pylint: disable=unused-import
+    build_query_args,
+    build_url,
+    default_http_error_handler,
+    HTTPClient,
+    requests,
+)

--- a/sap/http/client.py
+++ b/sap/http/client.py
@@ -1,0 +1,201 @@
+"""HTTP client for SAP ABAP systems built on top of Python requests."""
+
+import requests
+import requests.exceptions
+from requests.auth import HTTPBasicAuth
+
+from sap import get_logger, config_get
+from sap.http.errors import (
+    HTTPRequestError,
+    UnauthorizedError,
+    TimedOutRequestError,
+)
+
+
+def build_query_args(client=None, saml2=None):
+    """Build the query arguments for the ABAP HTTP request."""
+    args = {}
+
+    if saml2 is not None:
+        saml2_arg = 'enabled' if saml2 else 'disabled'
+        args['saml2'] = saml2_arg
+
+    if client is not None:
+        args['sap-client'] = client
+
+    return args
+
+
+def build_url(ssl=True, host=None, port=None, path=None, client=None, saml2=None):
+    """Build the base URL for the ABAP HTTP request."""
+
+    protocol = 'https' if ssl else 'http'
+    default_port = '443' if ssl else '80'
+    port = port or default_port
+
+    return f'{protocol}://{host}:{port}/{path}', build_query_args(client, saml2)
+
+
+def default_http_error_handler(client, req, res):
+    """Default error handler that raises UnauthorizedError for 401 and HTTPRequestError otherwise."""
+
+    if res.status_code == 401:
+        raise UnauthorizedError(req, res, client.user)
+
+    raise HTTPRequestError(req, res)
+
+
+# pylint: disable=too-many-instance-attributes
+class HTTPClient():
+    """HTTP client for SAP ABAP systems built on top of Python requests."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(self,
+                 ssl=True,
+                 host=None,
+                 port=None,
+                 user=None,
+                 password=None,
+                 saml2=None,
+                 client=None,
+                 verify=None,
+                 ssl_server_cert=None,
+                 login_path='',
+                 login_method='HEAD'
+                 ):
+
+        self.ssl = ssl
+        self.host = host
+        self.port = port
+        if ssl:
+            self.protocol = 'https'
+            if port is None:
+                self.port = '443'
+        else:
+            self.protocol = 'http'
+            if port is None:
+                self.port = '80'
+
+        self.ssl_verify = verify
+        self.ssl_server_cert = ssl_server_cert
+
+        self.user = user
+        self.client = client
+        self.saml2 = saml2
+        self.login_path = login_path
+        self.login_method = login_method
+
+        self.timeout = config_get('http_timeout')
+
+        self._auth = HTTPBasicAuth(user, password)
+
+        self.error_handlers = [default_http_error_handler]
+        self._connection_error_handler = None
+
+    def add_error_handler(self, handler):
+        """Add an error handler to the client.
+
+        The handler will be called with the request and response objects
+        when an error occurs.
+        """
+
+        self.error_handlers.insert(0, handler)
+
+    def handle_http_error(self, req, res):
+        """Raise the correct exception based on response content."""
+
+        for handler in self.error_handlers:
+            handler(self, req, res)
+
+    def set_connection_error_handler(self, handler):
+        """Set the connection error handler for the client.
+
+        The handler will be called with the client and error
+        when a connection error occurs.
+        """
+
+        self._connection_error_handler = handler
+
+    def retrieve(self, session, method, path, params=None, headers=None, body=None):
+        """Execute an HTTP request and return the raw (request, response) tuple."""
+
+        url, default_params = build_url(self.ssl, self.host, self.port, path, self.client, self.saml2)
+        default_params.update(params or {})
+        req = requests.Request(method.upper(), url, params=default_params, data=body, headers=headers)
+        req = session.prepare_request(req)
+
+        get_logger().info('Executing %s %s', method, url)
+
+        if body is not None:
+            get_logger().info('Body %s ', body)
+
+        try:
+            res = session.send(req, timeout=self.timeout)
+        except requests.exceptions.ConnectTimeout as ex:
+            raise TimedOutRequestError(req, self.timeout) from ex
+        except requests.exceptions.ReadTimeout as ex:
+            raise TimedOutRequestError(req, self.timeout) from ex
+        except requests.exceptions.ConnectionError as ex:
+            if self._connection_error_handler is not None:
+                self._connection_error_handler(self, ex)
+                # Handler must raise; if not we reraise the original exception
+            raise
+
+        get_logger().debug('Response %s %s:\n++++\n%s\n++++', method, url, res.text)
+
+        return (req, res)
+
+    def execute_with_session(self, session, method, path, params=None, headers=None, body=None):
+        """Executes the given URL using the given method in
+           the common HTTP session.
+        """
+
+        req, res = self.retrieve(session, method, path, params=params, headers=headers, body=body)
+
+        if res.status_code == 403 and (not headers or headers.get('x-csrf-token', '') != 'Fetch'):
+            get_logger().debug('Re-Fetching CSRF token')
+
+            session.headers.pop('x-csrf-token', None)
+
+            response = self.execute_with_session(
+                session,
+                self.login_method,
+                self.login_path,
+                headers={'x-csrf-token': 'Fetch'}
+            )
+
+            session.headers['x-csrf-token'] = response.headers['x-csrf-token']
+
+            req, res = self.retrieve(session, method, path, params=params, headers=headers, body=body)
+
+        if res.status_code >= 400:
+            self.handle_http_error(req, res)
+
+        return res
+
+    def build_session(self):
+        """Build the HTTP session for the ABAP HTTP request."""
+
+        session = requests.Session()
+        session.auth = self._auth
+
+        # requests.session.verify is either boolean or path to CA to use!
+        if self.ssl_server_cert:
+            session.verify = self.ssl_server_cert
+            get_logger().info('Using custom SSL Server cert path: %s', self.ssl_server_cert)
+        elif self.ssl_verify is False:
+            import urllib3
+            urllib3.disable_warnings()
+            get_logger().info('SSL Server cert will not be verified: SAP_SSL_VERIFY = no')
+            session.verify = False
+
+        login_headers = {'x-csrf-token': 'Fetch'}
+        csrf_token = None
+
+        response = self.execute_with_session(session, self.login_method, self.login_path, headers=login_headers)
+
+        if 'x-csrf-token' in response.headers:
+            csrf_token = response.headers['x-csrf-token']
+            session.headers.update({'x-csrf-token': csrf_token})
+
+        return session, response

--- a/sap/http/errors.py
+++ b/sap/http/errors.py
@@ -1,0 +1,94 @@
+"""HTTP error types shared across SAP CLI consumers"""
+
+import re
+
+from sap.errors import SAPCliError
+
+
+class UnexpectedResponseContent(SAPCliError):
+    """Exception for unexpected responses content"""
+
+    def __init__(self, expected, received, content):
+        super().__init__()
+
+        self.expected = expected
+        self.received = received
+        self.content = content
+
+    def __str__(self):
+        return f'Unexpected Content-Type: {self.received} with: {self.content}'
+
+
+class HTTPRequestError(SAPCliError):
+    """Exception for unexpected HTTP responses"""
+
+    def __init__(self, request, response):
+        super().__init__()
+
+        self.request = request
+        self.response = response
+        self.status_code = response.status_code
+
+    def _get_error_header(self):
+        return re.search('.*<p class="errorTextHeader"> *<span >(.*)</span> *</p>.*', self.response.text)
+
+    def _get_error_message(self):
+        error_msg = re.finditer(
+            '<p class="detailText"> *<span id="msgText">(.*?)</span> *</p>',
+            self.response.text,
+            flags=re.DOTALL
+        )
+        error_msg = [msg[1] for msg in error_msg if 'Server time:' not in msg[1]]
+        error_msg = [' '.join(msg.split('\n')) for msg in error_msg]
+        error_msg = '\n'.join(error_msg)
+
+        return error_msg
+
+    def __repr__(self):
+        error_text_header = self._get_error_header()
+        error_msg = self._get_error_message()
+        if error_text_header and error_msg:
+            return f'{error_text_header[1]}\n{error_msg}'
+
+        return f'{self.response.status_code}\n{self.response.text}'
+
+    def __str__(self):
+        return repr(self)
+
+
+class UnauthorizedError(SAPCliError):
+    """Exception for unauthorized """
+
+    def __init__(self, request, response, user):
+        super().__init__()
+
+        self.request = request
+        self.response = response
+        self.status_code = response.status_code
+        self.method = request.method
+        self.url = request.url
+        self.user = user
+
+    def __repr__(self):
+        return f'Authorization for the user "{self.user}" has failed: {self.method} {self.url}'
+
+    def __str__(self):
+        return repr(self)
+
+
+class TimedOutRequestError(SAPCliError):
+    """Exception for timeout requests"""
+
+    def __init__(self, request, timeout):
+        super().__init__()
+
+        self.request = request
+        self.method = request.method
+        self.url = request.url
+        self.timeout = timeout
+
+    def __repr__(self):
+        return f'The request {self.method} {self.url} took more than {self.timeout}s'
+
+    def __str__(self):
+        return repr(self)

--- a/sap/rest/connection.py
+++ b/sap/rest/connection.py
@@ -8,13 +8,13 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 from sap import get_logger, config_get
-from sap.rest.errors import (
+from sap.http import (
     HTTPRequestError,
     UnexpectedResponseContent,
     UnauthorizedError,
     TimedOutRequestError,
-    GCTSConnectionError,
 )
+from sap.rest.errors import GCTSConnectionError
 
 
 KEEPALIVE_CONFIGURED = False

--- a/sap/rest/errors.py
+++ b/sap/rest/errors.py
@@ -1,93 +1,13 @@
 """HTTP related errors"""
 
-import re
 from sap.errors import SAPCliError
 
-
-class UnexpectedResponseContent(SAPCliError):
-    """Exception for unexpected responses content"""
-
-    def __init__(self, expected, received, content):
-        super().__init__()
-
-        self.expected = expected
-        self.received = received
-        self.content = content
-
-    def __str__(self):
-        return f'Unexpected Content-Type: {self.received} with: {self.content}'
-
-
-class HTTPRequestError(SAPCliError):
-    """Exception for unexpected HTTP responses"""
-
-    def __init__(self, request, response):
-        super().__init__()
-
-        self.request = request
-        self.response = response
-        self.status_code = response.status_code
-
-    def _get_error_header(self):
-        return re.search('.*<p class="errorTextHeader"> *<span >(.*)</span> *</p>.*', self.response.text)
-
-    def _get_error_message(self):
-        error_msg = re.finditer('<p class="detailText"> *<span id="msgText">(.*?)</span> *</p>', self.response.text,
-                                flags=re.DOTALL)
-        error_msg = [msg[1] for msg in error_msg if 'Server time:' not in msg[1]]
-        error_msg = [' '.join(msg.split('\n')) for msg in error_msg]
-        error_msg = '\n'.join(error_msg)
-
-        return error_msg
-
-    def __repr__(self):
-        error_text_header = self._get_error_header()
-        error_msg = self._get_error_message()
-        if error_text_header and error_msg:
-            return f'{error_text_header[1]}\n{error_msg}'
-
-        return f'{self.response.status_code}\n{self.response.text}'
-
-    def __str__(self):
-        return repr(self)
-
-
-class UnauthorizedError(SAPCliError):
-    """Exception for unauthorized """
-
-    def __init__(self, request, response, user):
-        super().__init__()
-
-        self.request = request
-        self.response = response
-        self.status_code = response.status_code
-        self.method = request.method
-        self.url = request.url
-        self.user = user
-
-    def __repr__(self):
-        return f'Authorization for the user "{self.user}" has failed: {self.method} {self.url}'
-
-    def __str__(self):
-        return repr(self)
-
-
-class TimedOutRequestError(SAPCliError):
-    """Exception for timeout requests"""
-
-    def __init__(self, request, timeout):
-        super().__init__()
-
-        self.request = request
-        self.method = request.method
-        self.url = request.url
-        self.timeout = timeout
-
-    def __repr__(self):
-        return f'The request {self.method} {self.url} took more than {self.timeout}s'
-
-    def __str__(self):
-        return repr(self)
+from sap.http import (  # noqa: F401  # pylint: disable=unused-import
+    HTTPRequestError,
+    UnexpectedResponseContent,
+    UnauthorizedError,
+    TimedOutRequestError,
+)
 
 
 class GCTSConnectionError(SAPCliError):

--- a/sap/rest/gcts/activities.py
+++ b/sap/rest/gcts/activities.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from typing import Union
 
-from sap.rest.errors import HTTPRequestError
+from sap.http import HTTPRequestError
 from sap.rest.gcts.errors import SAPCliError
 from sap.rest.gcts.remote_repo import Repository, RepoActivitiesQueryParams
 

--- a/sap/rest/gcts/remote_repo.py
+++ b/sap/rest/gcts/remote_repo.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from sap import get_logger
 
-from sap.rest.errors import HTTPRequestError
+from sap.http import HTTPRequestError
 
 from sap.rest.gcts.errors import exception_from_http_error, SAPCliError
 from sap.rest.gcts.log_messages import ActionMessage

--- a/sap/rest/gcts/repo_task.py
+++ b/sap/rest/gcts/repo_task.py
@@ -5,7 +5,7 @@ from enum import Enum
 from sap import get_logger
 
 
-from sap.rest.errors import HTTPRequestError
+from sap.http import HTTPRequestError
 
 from sap.rest.gcts.errors import (
     SAPCliError,

--- a/sap/rest/gcts/simple.py
+++ b/sap/rest/gcts/simple.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from sap import get_logger
 from sap.errors import OperationTimeoutError
-from sap.rest.errors import HTTPRequestError
+from sap.http import HTTPRequestError
 from sap.rest.gcts.remote_repo import Repository
 from sap.rest.gcts.repo_task import RepositoryTask
 from sap.rest.gcts.errors import (

--- a/test/unit/mock.py
+++ b/test/unit/mock.py
@@ -10,6 +10,7 @@ import unittest
 from unittest.mock import patch, MagicMock, Mock
 
 import sap.adt
+import sap.rest
 import sap.cli.core
 
 
@@ -234,6 +235,9 @@ class Connection(sap.adt.Connection):
         self.asserter = asserter if asserter is not None else SimpleAsserter()
         self.set_responses_iter(ok_responses() if responses is None else iter(responses))
 
+        # Rewire _http_client.retrieve to use our mock _retrieve
+        self._http_client.retrieve = self._retrieve
+
     def set_responses(self, *responses):
         if responses and isinstance(responses[0], list):
             responses = responses[0]
@@ -276,7 +280,7 @@ class Connection(sap.adt.Connection):
         if self.collections is None:
             return [default_mimetype]
 
-        return self.collections[f'/{self._adt_uri}/{basepath}']
+        return self.collections[f'/{self.uri}/{basepath}']
 
 
 def empty_rfc_responses():

--- a/test/unit/test_sap_adt_connection.py
+++ b/test/unit/test_sap_adt_connection.py
@@ -6,6 +6,7 @@ from requests.exceptions import ConnectionError, ReadTimeout
 
 import sap.adt
 import sap.adt.errors
+import sap.http
 import sap.rest.errors
 
 from mock import Request, Response, Connection
@@ -24,23 +25,31 @@ class TestADTConnection(unittest.TestCase):
 
         self.assertEqual(connection.user, 'anzeiger')
         self.assertEqual(connection.uri, 'sap/bc/adt')
-        self.assertEqual(connection._base_url, 'https://localhost:443/sap/bc/adt')
-        self.assertEqual(connection._query_args, 'sap-client=357&saml2=disabled')
+        self.assertEqual(connection._http_client.host, 'localhost')
+        self.assertEqual(connection._http_client.port, '443')
+        self.assertEqual(connection._http_client.ssl, True)
+        self.assertEqual(connection._http_client.client, '357')
 
     def test_adt_connection_init_no_ssl(self):
         connection = sap.adt.Connection('localhost', '357', 'anzeiger', 'password', ssl=False)
 
-        self.assertEqual(connection._base_url, 'http://localhost:80/sap/bc/adt')
+        self.assertEqual(connection._http_client.host, 'localhost')
+        self.assertEqual(connection._http_client.port, '80')
+        self.assertEqual(connection._http_client.ssl, False)
 
     def test_adt_connection_init_ssl_own_port(self):
         connection = sap.adt.Connection('localhost', '357', 'anzeiger', 'password', port=44300)
 
-        self.assertEqual(connection._base_url, 'https://localhost:44300/sap/bc/adt')
+        self.assertEqual(connection._http_client.host, 'localhost')
+        self.assertEqual(connection._http_client.port, 44300)
+        self.assertEqual(connection._http_client.ssl, True)
 
     def test_adt_connection_init_no_ssl_own_port(self):
         connection = sap.adt.Connection('localhost', '357', 'anzeiger', 'password', ssl=False, port=8000)
 
-        self.assertEqual(connection._base_url, 'http://localhost:8000/sap/bc/adt')
+        self.assertEqual(connection._http_client.host, 'localhost')
+        self.assertEqual(connection._http_client.port, 8000)
+        self.assertEqual(connection._http_client.ssl, False)
 
     def test_handle_http_error_adt_exception(self):
         req = Mock()
@@ -51,7 +60,7 @@ class TestADTConnection(unittest.TestCase):
         res.text = ERROR_XML_PACKAGE_ALREADY_EXISTS
 
         with self.assertRaises(sap.adt.errors.ADTError):
-            self.connection._handle_http_error(req, res)
+            self.connection._http_client.handle_http_error(req, res)
 
     def test_handle_http_error_random_xml(self):
         req = Mock()
@@ -61,8 +70,8 @@ class TestADTConnection(unittest.TestCase):
         res.headers = {'content-type': 'application/xml'}
         res.text = '<?xml version="1.0" encoding="utf-8"><error>random failure</error>'
 
-        with self.assertRaises(sap.rest.errors.HTTPRequestError):
-            self.connection._handle_http_error(req, res)
+        with self.assertRaises(sap.http.HTTPRequestError):
+            self.connection._http_client.handle_http_error(req, res)
 
     def test_handle_http_error_plain_text(self):
         req = Mock()
@@ -72,8 +81,8 @@ class TestADTConnection(unittest.TestCase):
         res.headers = {'content-type': 'plain/text'}
         res.text = 'arbitrary crash'
 
-        with self.assertRaises(sap.rest.errors.HTTPRequestError):
-            self.connection._handle_http_error(req, res)
+        with self.assertRaises(sap.http.HTTPRequestError):
+            self.connection._http_client.handle_http_error(req, res)
 
     def test_handle_http_error_unauthorized(self):
         req = Mock()
@@ -83,12 +92,12 @@ class TestADTConnection(unittest.TestCase):
         res.headers = {'content-type': 'plain/text'}
         res.text = 'arbitrary crash'
 
-        with self.assertRaises(sap.rest.errors.UnauthorizedError):
-            self.connection._handle_http_error(req, res)
+        with self.assertRaises(sap.http.UnauthorizedError):
+            self.connection._http_client.handle_http_error(req, res)
 
     @patch('sap.adt.core.Connection._build_adt_url', return_value='url')
     @patch('sap.adt.core.Connection._get_session', return_value='session')
-    @patch('sap.adt.core.Connection._execute_with_session')
+    @patch('sap.http.HTTPClient.execute_with_session')
     def test_execute_content_type_no_headers(self, mock_exec, mock_session, mock_adt_url):
         self.connection.execute('GET', 'url', content_type='application/xml')
 
@@ -99,7 +108,7 @@ class TestADTConnection(unittest.TestCase):
 
     @patch('sap.adt.core.Connection._build_adt_url', return_value='url')
     @patch('sap.adt.core.Connection._get_session', return_value='session')
-    @patch('sap.adt.core.Connection._execute_with_session')
+    @patch('sap.http.HTTPClient.execute_with_session')
     def test_execute_content_type_with_headers(self, mock_exec, mock_session, mock_adt_url):
         self.connection.execute('GET', 'example',
                                 headers={'Content-Type': 'text/plain'},
@@ -112,7 +121,7 @@ class TestADTConnection(unittest.TestCase):
 
     @patch('sap.adt.core.Connection._build_adt_url', return_value='url')
     @patch('sap.adt.core.Connection._get_session', return_value='session')
-    @patch('sap.adt.core.Connection._execute_with_session')
+    @patch('sap.http.HTTPClient.execute_with_session')
     def test_execute_accept_no_headers(self, mock_exec, mock_session, mock_adt_url):
         mock_exec.return_value = Mock()
         mock_exec.return_value.headers = {'Content-Type': 'application/xml'}
@@ -127,7 +136,7 @@ class TestADTConnection(unittest.TestCase):
 
     @patch('sap.adt.core.Connection._build_adt_url', return_value='url')
     @patch('sap.adt.core.Connection._get_session', return_value='session')
-    @patch('sap.adt.core.Connection._execute_with_session')
+    @patch('sap.http.HTTPClient.execute_with_session')
     def test_execute_accept_with_headers(self, mock_exec, mock_session, mock_adt_url):
         mock_exec.return_value = Mock()
         mock_exec.return_value.headers = {'Content-Type': 'application/xml'}
@@ -143,7 +152,7 @@ class TestADTConnection(unittest.TestCase):
 
     @patch('sap.adt.core.Connection._build_adt_url', return_value='url')
     @patch('sap.adt.core.Connection._get_session', return_value='session')
-    @patch('sap.adt.core.Connection._execute_with_session')
+    @patch('sap.http.HTTPClient.execute_with_session')
     def test_execute_content_type_and_accept(self, mock_exec, mock_session, mock_adt_url):
         mock_exec.return_value = Mock()
         mock_exec.return_value.headers = {'Content-Type': 'application/xml'}
@@ -160,7 +169,7 @@ class TestADTConnection(unittest.TestCase):
 
     @patch('sap.adt.core.Connection._build_adt_url', return_value='url')
     @patch('sap.adt.core.Connection._get_session', return_value='session')
-    @patch('sap.adt.core.Connection._execute_with_session')
+    @patch('sap.http.HTTPClient.execute_with_session')
     def test_execute_content_type_and_accept_with_headers(self, mock_exec, mock_session, mock_adt_url):
         mock_exec.return_value = Mock()
         mock_exec.return_value.headers = {'Content-Type': 'application/xml'}
@@ -179,7 +188,7 @@ class TestADTConnection(unittest.TestCase):
 
     @patch('sap.adt.core.Connection._build_adt_url', return_value='url')
     @patch('sap.adt.core.Connection._get_session', return_value='session')
-    @patch('sap.adt.core.Connection._execute_with_session')
+    @patch('sap.http.HTTPClient.execute_with_session')
     def test_execute_accept_list(self, mock_exec, mock_session, mock_adt_url):
         mock_exec.return_value = Mock()
         mock_exec.return_value.headers = {'Content-Type': 'application/json'}
@@ -194,13 +203,13 @@ class TestADTConnection(unittest.TestCase):
 
     @patch('sap.adt.core.Connection._build_adt_url', return_value='url')
     @patch('sap.adt.core.Connection._get_session', return_value='session')
-    @patch('sap.adt.core.Connection._execute_with_session')
+    @patch('sap.http.HTTPClient.execute_with_session')
     def test_execute_accept_unmatched_string(self, mock_exec, mock_session, mock_adt_url):
         mock_exec.return_value = Mock()
         mock_exec.return_value.headers = {'Content-Type': 'application/json'}
         mock_exec.return_value.text = 'mock'
 
-        with self.assertRaises(sap.rest.errors.UnexpectedResponseContent) as caught:
+        with self.assertRaises(sap.http.UnexpectedResponseContent) as caught:
             self.connection.execute('GET', 'example',
                                     accept='application/xml')
 
@@ -209,13 +218,13 @@ class TestADTConnection(unittest.TestCase):
 
     @patch('sap.adt.core.Connection._build_adt_url', return_value='url')
     @patch('sap.adt.core.Connection._get_session', return_value='session')
-    @patch('sap.adt.core.Connection._execute_with_session')
+    @patch('sap.http.HTTPClient.execute_with_session')
     def test_execute_accept_unmatched_list(self, mock_exec, mock_session, mock_adt_url):
         mock_exec.return_value = Mock()
         mock_exec.return_value.headers = {'Content-Type': 'text/plain'}
         mock_exec.return_value.text = 'mock'
 
-        with self.assertRaises(sap.rest.errors.UnexpectedResponseContent) as caught:
+        with self.assertRaises(sap.http.UnexpectedResponseContent) as caught:
             self.connection.execute('GET', 'example',
                                     accept=['application/xml', 'application/json'])
 
@@ -273,7 +282,7 @@ class TestADTConnection(unittest.TestCase):
             self.assertEqual(act_types, exp_mimetypes)
 
     @patch('sap.adt.core._get_collection_accepts')
-    @patch('sap.adt.core.Connection._retrieve')
+    @patch('sap.http.HTTPClient.retrieve')
     def test_execute_session_new(self, fake_retrieve, fake_accepts):
         dummy_conn = Connection(responses=[
             Response(status_code=200, headers={'x-csrf-token': 'first'}),
@@ -288,7 +297,7 @@ class TestADTConnection(unittest.TestCase):
         self.assertEqual(resp.text, 'success')
 
     @patch('sap.adt.core._get_collection_accepts')
-    @patch('sap.adt.core.Connection._retrieve')
+    @patch('sap.http.HTTPClient.retrieve')
     def test_execute_session_new_forbidden(self, fake_retrieve, fake_accepts):
         dummy_conn = Connection(responses=[
             Response(text='''<?xml version="1.0" encoding="utf-8"?><mock type=test/>''',
@@ -298,11 +307,11 @@ class TestADTConnection(unittest.TestCase):
 
         fake_retrieve.side_effect = dummy_conn._retrieve
 
-        with self.assertRaises(sap.rest.errors.HTTPRequestError):
+        with self.assertRaises(sap.http.HTTPRequestError):
             self.connection.execute('GET', 'test')
 
     @patch('sap.adt.core._get_collection_accepts')
-    @patch('sap.adt.core.Connection._retrieve')
+    @patch('sap.http.HTTPClient.retrieve')
     def test_execute_session_refetch_csfr(self, fake_retrieve, fake_accepts):
         dummy_conn = Connection(responses=[
             Response(status_code=200, headers={'x-csrf-token': 'first'}),
@@ -320,7 +329,7 @@ class TestADTConnection(unittest.TestCase):
         self.assertEqual(resp.text, 'success')
 
     @patch('sap.adt.core._get_collection_accepts')
-    @patch('sap.adt.core.Connection._retrieve')
+    @patch('sap.http.HTTPClient.retrieve')
     def test_execute_session_refetch_csfr_headers(self, fake_retrieve, fake_accepts):
         dummy_conn = Connection(responses=[
             Response(status_code=200, headers={'x-csrf-token': 'first'}),
@@ -337,49 +346,55 @@ class TestADTConnection(unittest.TestCase):
         resp = self.connection.execute('GET', 'test', headers={'awesome': 'fabulous'})
         self.assertEqual(resp.text, 'success')
 
-    @patch('sap.adt.core.requests.Request')
+    @patch('sap.http.requests.Request')
     def test_protocol_error(self, _):
         session = Mock()
         session.send.side_effect = ConnectionError('Remote end closed connection without response')
 
         with self.assertRaises(sap.adt.errors.ADTConnectionError) as cm:
-            self.connection._retrieve(session, 'method', 'url')
+            self.connection._http_client.retrieve(session, 'method', 'url')
 
         self.assertEqual(str(cm.exception),
-                         f'ADT Connection error: [HOST:"{self.connection._host}", PORT:"{self.connection._port}", '
-                         f'SSL:"{self.connection._ssl}"] Error: Remote end closed connection without response')
+                         f'ADT Connection error: [HOST:"{self.connection._http_client.host}", '
+                         f'PORT:"{self.connection._http_client.port}", '
+                         f'SSL:"{self.connection._http_client.ssl}"] Error: '
+                         f'Remote end closed connection without response')
 
-    @patch('sap.adt.core.requests.Request')
+    @patch('sap.http.requests.Request')
     def test_dns_error(self, _):
         session = Mock()
         session.send.side_effect = ConnectionError('[Errno -5] Dummy name resolution error.')
 
         with self.assertRaises(sap.adt.errors.ADTConnectionError) as cm:
-            self.connection._retrieve(session, 'method', 'url')
+            self.connection._http_client.retrieve(session, 'method', 'url')
 
         self.assertEqual(str(cm.exception),
-                         f'ADT Connection error: [HOST:"{self.connection._host}", PORT:"{self.connection._port}", '
-                         f'SSL:"{self.connection._ssl}"] Error: Name resolution error. Check the HOST configuration.')
+                         f'ADT Connection error: [HOST:"{self.connection._http_client.host}", '
+                         f'PORT:"{self.connection._http_client.port}", '
+                         f'SSL:"{self.connection._http_client.ssl}"] Error: '
+                         f'Name resolution error. Check the HOST configuration.')
 
-    @patch('sap.adt.core.requests.Request')
+    @patch('sap.http.requests.Request')
     def test_connection_error(self, _):
         session = Mock()
         session.send.side_effect = ConnectionError('[Errno 111] Dummy connection error.')
 
         with self.assertRaises(sap.adt.errors.ADTConnectionError) as cm:
-            self.connection._retrieve(session, 'method', 'url')
+            self.connection._http_client.retrieve(session, 'method', 'url')
 
         self.assertEqual(str(cm.exception),
-                         f'ADT Connection error: [HOST:"{self.connection._host}", PORT:"{self.connection._port}", '
-                         f'SSL:"{self.connection._ssl}"] Error: Cannot connect to the system. Check the HOST and PORT configuration.')
+                         f'ADT Connection error: [HOST:"{self.connection._http_client.host}", '
+                         f'PORT:"{self.connection._http_client.port}", '
+                         f'SSL:"{self.connection._http_client.ssl}"] Error: '
+                         f'Cannot connect to the system. Check the HOST and PORT configuration.')
 
-    @patch('sap.adt.core.requests.Request')
+    @patch('sap.http.requests.Request')
     def test_read_timeout(self, _):
         session = Mock()
         session.send.side_effect = ReadTimeout('HTTPSConnectionPool read timed out')
 
-        with self.assertRaises(sap.rest.errors.TimedOutRequestError) as cm:
-            self.connection._retrieve(session, 'method', 'url')
+        with self.assertRaises(sap.http.TimedOutRequestError) as cm:
+            self.connection._http_client.retrieve(session, 'method', 'url')
 
         self.assertIn('took more than', str(cm.exception))
 
@@ -389,15 +404,15 @@ class TestADTConnectionSSLServerCert(unittest.TestCase):
 
     def test_ssl_server_cert_default_none(self):
         connection = sap.adt.Connection('localhost', '357', 'user', 'pass')
-        self.assertIsNone(connection._ssl_server_cert)
+        self.assertIsNone(connection._http_client.ssl_server_cert)
 
     def test_ssl_server_cert_stored(self):
         connection = sap.adt.Connection('localhost', '357', 'user', 'pass',
                                         ssl_server_cert='/path/to/ca.pem')
-        self.assertEqual(connection._ssl_server_cert, '/path/to/ca.pem')
+        self.assertEqual(connection._http_client.ssl_server_cert, '/path/to/ca.pem')
 
     @patch('sap.adt.core.Connection._build_adt_url', return_value='url')
-    @patch('sap.adt.core.Connection._execute_with_session')
+    @patch('sap.http.HTTPClient.execute_with_session')
     def test_ssl_server_cert_sets_session_verify(self, mock_exec, mock_url):
         """When ssl_server_cert is set, session.verify is the cert path."""
         mock_response = Mock()
@@ -412,7 +427,7 @@ class TestADTConnectionSSLServerCert(unittest.TestCase):
         self.assertEqual(session.verify, '/path/to/ca.pem')
 
     @patch('sap.adt.core.Connection._build_adt_url', return_value='url')
-    @patch('sap.adt.core.Connection._execute_with_session')
+    @patch('sap.http.HTTPClient.execute_with_session')
     def test_ssl_server_cert_none_verify_true(self, mock_exec, mock_url):
         """Without ssl_server_cert, session.verify defaults to True."""
         mock_response = Mock()
@@ -426,7 +441,7 @@ class TestADTConnectionSSLServerCert(unittest.TestCase):
         self.assertTrue(session.verify)
 
     @patch('sap.adt.core.Connection._build_adt_url', return_value='url')
-    @patch('sap.adt.core.Connection._execute_with_session')
+    @patch('sap.http.HTTPClient.execute_with_session')
     def test_ssl_server_cert_takes_precedence_over_verify_false(self, mock_exec, mock_url):
         """ssl_server_cert takes precedence over verify=False."""
         mock_response = Mock()

--- a/test/unit/test_sap_http_client.py
+++ b/test/unit/test_sap_http_client.py
@@ -1,0 +1,763 @@
+#!/usr/bin/env python3
+
+import unittest
+from unittest.mock import Mock, patch, MagicMock
+
+import requests.exceptions
+
+from sap.http.client import (
+    build_query_args,
+    build_url,
+    default_http_error_handler,
+    HTTPClient,
+)
+from sap.http.errors import (
+    HTTPRequestError,
+    UnauthorizedError,
+    TimedOutRequestError,
+)
+
+
+class TestBuildQueryArgs(unittest.TestCase):
+
+    def test_no_arguments(self):
+        self.assertEqual(build_query_args(), {})
+
+    def test_client_only(self):
+        self.assertEqual(build_query_args(client='100'), {'sap-client': '100'})
+
+    def test_saml2_enabled(self):
+        self.assertEqual(build_query_args(saml2=True), {'saml2': 'enabled'})
+
+    def test_saml2_disabled(self):
+        self.assertEqual(build_query_args(saml2=False), {'saml2': 'disabled'})
+
+    def test_client_and_saml2(self):
+        result = build_query_args(client='200', saml2=True)
+        self.assertEqual(result, {'sap-client': '200', 'saml2': 'enabled'})
+
+    def test_none_values_ignored(self):
+        result = build_query_args(client=None, saml2=None)
+        self.assertEqual(result, {})
+
+
+class TestBuildUrl(unittest.TestCase):
+
+    def test_ssl_defaults(self):
+        url, params = build_url(host='example.com', path='sap/bc/adt')
+
+        self.assertEqual(url, 'https://example.com:443/sap/bc/adt')
+        self.assertEqual(params, {})
+
+    def test_no_ssl_defaults(self):
+        url, params = build_url(ssl=False, host='example.com', path='sap/bc/adt')
+
+        self.assertEqual(url, 'http://example.com:80/sap/bc/adt')
+        self.assertEqual(params, {})
+
+    def test_custom_port(self):
+        url, _ = build_url(host='example.com', port='8443', path='sap/bc/adt')
+
+        self.assertEqual(url, 'https://example.com:8443/sap/bc/adt')
+
+    def test_no_ssl_custom_port(self):
+        url, _ = build_url(ssl=False, host='example.com', port='8080', path='api')
+
+        self.assertEqual(url, 'http://example.com:8080/api')
+
+    def test_with_client_and_saml2(self):
+        url, params = build_url(host='example.com', path='sap/bc/adt', client='100', saml2=True)
+
+        self.assertEqual(url, 'https://example.com:443/sap/bc/adt')
+        self.assertEqual(params, {'sap-client': '100', 'saml2': 'enabled'})
+
+
+class TestDefaultHttpErrorHandler(unittest.TestCase):
+
+    def test_raises_unauthorized_for_401(self):
+        client = Mock()
+        client.user = 'SAP*'
+        req = Mock()
+        res = Mock()
+        res.status_code = 401
+
+        with self.assertRaises(UnauthorizedError) as cm:
+            default_http_error_handler(client, req, res)
+
+        self.assertIs(cm.exception.request, req)
+        self.assertIs(cm.exception.response, res)
+        self.assertEqual(cm.exception.user, 'SAP*')
+
+    def test_raises_http_request_error_for_non_401(self):
+        client = Mock()
+        req = Mock()
+        res = Mock()
+        res.status_code = 500
+
+        with self.assertRaises(HTTPRequestError) as cm:
+            default_http_error_handler(client, req, res)
+
+        self.assertIs(cm.exception.request, req)
+        self.assertIs(cm.exception.response, res)
+        self.assertEqual(cm.exception.status_code, 500)
+
+    def test_raises_http_request_error_for_403(self):
+        client = Mock()
+        req = Mock()
+        res = Mock()
+        res.status_code = 403
+
+        with self.assertRaises(HTTPRequestError):
+            default_http_error_handler(client, req, res)
+
+    def test_raises_http_request_error_for_404(self):
+        client = Mock()
+        req = Mock()
+        res = Mock()
+        res.status_code = 404
+
+        with self.assertRaises(HTTPRequestError):
+            default_http_error_handler(client, req, res)
+
+
+class TestHTTPClientInit(unittest.TestCase):
+
+    def test_defaults_ssl(self):
+        client = HTTPClient(host='example.com', user='SAP*', password='pass')
+
+        self.assertTrue(client.ssl)
+        self.assertEqual(client.host, 'example.com')
+        self.assertEqual(client.port, '443')
+        self.assertEqual(client.protocol, 'https')
+        self.assertEqual(client.user, 'SAP*')
+        self.assertIsNone(client.client)
+        self.assertIsNone(client.saml2)
+        self.assertEqual(client.login_path, '')
+        self.assertEqual(client.login_method, 'HEAD')
+        self.assertIsNone(client.ssl_verify)
+        self.assertIsNone(client.ssl_server_cert)
+
+    def test_defaults_no_ssl(self):
+        client = HTTPClient(ssl=False, host='example.com', user='SAP*', password='pass')
+
+        self.assertFalse(client.ssl)
+        self.assertEqual(client.port, '80')
+        self.assertEqual(client.protocol, 'http')
+
+    def test_custom_port_ssl(self):
+        client = HTTPClient(host='example.com', port='8443', user='u', password='p')
+
+        self.assertEqual(client.port, '8443')
+        self.assertEqual(client.protocol, 'https')
+
+    def test_custom_port_no_ssl(self):
+        client = HTTPClient(ssl=False, host='example.com', port='8080', user='u', password='p')
+
+        self.assertEqual(client.port, '8080')
+        self.assertEqual(client.protocol, 'http')
+
+    def test_all_parameters(self):
+        client = HTTPClient(
+            ssl=True,
+            host='myhost',
+            port='44300',
+            user='admin',
+            password='secret',
+            saml2=True,
+            client='100',
+            verify=False,
+            ssl_server_cert='/path/to/cert.pem',
+            login_path='sap/bc/adt',
+            login_method='GET'
+        )
+
+        self.assertEqual(client.host, 'myhost')
+        self.assertEqual(client.port, '44300')
+        self.assertEqual(client.user, 'admin')
+        self.assertTrue(client.saml2)
+        self.assertEqual(client.client, '100')
+        self.assertFalse(client.ssl_verify)
+        self.assertEqual(client.ssl_server_cert, '/path/to/cert.pem')
+        self.assertEqual(client.login_path, 'sap/bc/adt')
+        self.assertEqual(client.login_method, 'GET')
+
+    def test_default_error_handlers(self):
+        client = HTTPClient(host='h', user='u', password='p')
+
+        self.assertEqual(len(client.error_handlers), 1)
+        self.assertIs(client.error_handlers[0], default_http_error_handler)
+
+    def test_no_connection_error_handler(self):
+        client = HTTPClient(host='h', user='u', password='p')
+
+        self.assertIsNone(client._connection_error_handler)
+
+
+class TestHTTPClientAddErrorHandler(unittest.TestCase):
+
+    def test_add_error_handler_prepends(self):
+        client = HTTPClient(host='h', user='u', password='p')
+        custom_handler = Mock()
+
+        client.add_error_handler(custom_handler)
+
+        self.assertEqual(len(client.error_handlers), 2)
+        self.assertIs(client.error_handlers[0], custom_handler)
+        self.assertIs(client.error_handlers[1], default_http_error_handler)
+
+    def test_add_multiple_handlers_order(self):
+        client = HTTPClient(host='h', user='u', password='p')
+        first = Mock()
+        second = Mock()
+
+        client.add_error_handler(first)
+        client.add_error_handler(second)
+
+        self.assertEqual(len(client.error_handlers), 3)
+        self.assertIs(client.error_handlers[0], second)
+        self.assertIs(client.error_handlers[1], first)
+        self.assertIs(client.error_handlers[2], default_http_error_handler)
+
+
+class TestHTTPClientHandleHttpError(unittest.TestCase):
+
+    def test_calls_handlers_in_order(self):
+        client = HTTPClient(host='h', user='u', password='p')
+        call_order = []
+
+        def handler1(c, req, res):
+            call_order.append('handler1')
+
+        def handler2(c, req, res):
+            call_order.append('handler2')
+
+        client.error_handlers = [handler1, handler2]
+        client.handle_http_error(Mock(), Mock())
+
+        self.assertEqual(call_order, ['handler1', 'handler2'])
+
+    def test_stops_at_first_raising_handler(self):
+        client = HTTPClient(host='h', user='u', password='p')
+
+        def raising_handler(c, req, res):
+            raise HTTPRequestError(req, res)
+
+        unreachable = Mock()
+        client.error_handlers = [raising_handler, unreachable]
+
+        with self.assertRaises(HTTPRequestError):
+            client.handle_http_error(Mock(), Mock(status_code=500, text='err'))
+
+        unreachable.assert_not_called()
+
+    def test_default_handler_raises_unauthorized(self):
+        client = HTTPClient(host='h', user='u', password='p')
+        req = Mock()
+        res = Mock()
+        res.status_code = 401
+
+        with self.assertRaises(UnauthorizedError):
+            client.handle_http_error(req, res)
+
+    def test_default_handler_raises_http_request_error(self):
+        client = HTTPClient(host='h', user='u', password='p')
+        req = Mock()
+        res = Mock()
+        res.status_code = 500
+
+        with self.assertRaises(HTTPRequestError):
+            client.handle_http_error(req, res)
+
+
+class TestHTTPClientSetConnectionErrorHandler(unittest.TestCase):
+
+    def test_set_connection_error_handler(self):
+        client = HTTPClient(host='h', user='u', password='p')
+        handler = Mock()
+
+        client.set_connection_error_handler(handler)
+
+        self.assertIs(client._connection_error_handler, handler)
+
+
+class TestHTTPClientRetrieve(unittest.TestCase):
+
+    def _make_client(self, **kwargs):
+        defaults = dict(host='example.com', user='SAP*', password='pass', client='100')
+        defaults.update(kwargs)
+        return HTTPClient(**defaults)
+
+    @patch('sap.http.client.requests.Request')
+    def test_retrieve_success(self, mock_request_cls):
+        client = self._make_client()
+        session = Mock()
+
+        prepared = Mock()
+        session.prepare_request.return_value = prepared
+
+        response = Mock()
+        response.text = 'OK'
+        session.send.return_value = response
+
+        req, res = client.retrieve(session, 'GET', 'sap/bc/adt')
+
+        self.assertIs(req, prepared)
+        self.assertIs(res, response)
+        session.send.assert_called_once_with(prepared, timeout=client.timeout)
+
+    @patch('sap.http.client.requests.Request')
+    def test_retrieve_builds_url(self, mock_request_cls):
+        client = self._make_client(ssl=True, host='myhost', port='44300', client='200', saml2=True)
+        session = Mock()
+        session.prepare_request.return_value = Mock()
+        session.send.return_value = Mock(text='')
+
+        client.retrieve(session, 'POST', 'api/path', params={'foo': 'bar'}, headers={'X-H': '1'}, body='data')
+
+        mock_request_cls.assert_called_once()
+        args, kwargs = mock_request_cls.call_args
+        self.assertEqual(args[0], 'POST')
+        self.assertEqual(args[1], 'https://myhost:44300/api/path')
+        self.assertEqual(kwargs['params'], {'sap-client': '200', 'saml2': 'enabled', 'foo': 'bar'})
+        self.assertEqual(kwargs['data'], 'data')
+        self.assertEqual(kwargs['headers'], {'X-H': '1'})
+
+    @patch('sap.http.client.requests.Request')
+    def test_retrieve_method_uppercased(self, mock_request_cls):
+        client = self._make_client()
+        session = Mock()
+        session.prepare_request.return_value = Mock()
+        session.send.return_value = Mock(text='')
+
+        client.retrieve(session, 'get', 'path')
+
+        args = mock_request_cls.call_args[0]
+        self.assertEqual(args[0], 'GET')
+
+    @patch('sap.http.client.requests.Request')
+    def test_retrieve_connect_timeout(self, mock_request_cls):
+        client = self._make_client()
+        session = Mock()
+        session.prepare_request.return_value = Mock(method='GET', url='https://example.com:443/path')
+        session.send.side_effect = requests.exceptions.ConnectTimeout('connect timed out')
+
+        with self.assertRaises(TimedOutRequestError) as cm:
+            client.retrieve(session, 'GET', 'path')
+
+        self.assertEqual(cm.exception.timeout, client.timeout)
+
+    @patch('sap.http.client.requests.Request')
+    def test_retrieve_read_timeout(self, mock_request_cls):
+        client = self._make_client()
+        session = Mock()
+        session.prepare_request.return_value = Mock(method='GET', url='https://example.com:443/path')
+        session.send.side_effect = requests.exceptions.ReadTimeout('read timed out')
+
+        with self.assertRaises(TimedOutRequestError) as cm:
+            client.retrieve(session, 'GET', 'path')
+
+        self.assertEqual(cm.exception.timeout, client.timeout)
+
+    @patch('sap.http.client.requests.Request')
+    def test_retrieve_connection_error_no_handler_reraises(self, mock_request_cls):
+        client = self._make_client()
+        session = Mock()
+        session.prepare_request.return_value = Mock()
+        session.send.side_effect = requests.exceptions.ConnectionError('connection refused')
+
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            client.retrieve(session, 'GET', 'path')
+
+    @patch('sap.http.client.requests.Request')
+    def test_retrieve_connection_error_handler_no_raise_reraises(self, mock_request_cls):
+        client = self._make_client()
+        handler = Mock()
+        client.set_connection_error_handler(handler)
+
+        session = Mock()
+        session.prepare_request.return_value = Mock()
+        conn_error = requests.exceptions.ConnectionError('connection refused')
+        session.send.side_effect = conn_error
+
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            client.retrieve(session, 'GET', 'path')
+
+        handler.assert_called_once_with(client, conn_error)
+
+    @patch('sap.http.client.requests.Request')
+    def test_retrieve_connection_error_with_handler(self, mock_request_cls):
+        client = self._make_client()
+        handler = Mock()
+        client.set_connection_error_handler(handler)
+
+        session = Mock()
+        session.prepare_request.return_value = Mock()
+        conn_error = requests.exceptions.ConnectionError('connection refused')
+        session.send.side_effect = conn_error
+
+        # The handler is called; retrieve continues (returns res which will fail
+        # because session.send raised, but the handler swallows it).
+        # In the real code, the handler typically raises a different exception.
+        # Here the handler doesn't raise, so code falls through to res.text
+        # which will fail. Let's have the handler raise to mimic real usage.
+        handler.side_effect = RuntimeError('handled')
+
+        with self.assertRaises(RuntimeError):
+            client.retrieve(session, 'GET', 'path')
+
+        handler.assert_called_once_with(client, conn_error)
+
+    @patch('sap.http.client.requests.Request')
+    def test_retrieve_default_params_merged(self, mock_request_cls):
+        client = self._make_client(client='100')
+        session = Mock()
+        session.prepare_request.return_value = Mock()
+        session.send.return_value = Mock(text='')
+
+        client.retrieve(session, 'GET', 'path', params={'extra': 'val'})
+
+        kwargs = mock_request_cls.call_args[1]
+        self.assertIn('sap-client', kwargs['params'])
+        self.assertEqual(kwargs['params']['sap-client'], '100')
+        self.assertEqual(kwargs['params']['extra'], 'val')
+
+    @patch('sap.http.client.requests.Request')
+    def test_retrieve_no_extra_params(self, mock_request_cls):
+        client = self._make_client(client='100')
+        session = Mock()
+        session.prepare_request.return_value = Mock()
+        session.send.return_value = Mock(text='')
+
+        client.retrieve(session, 'GET', 'path')
+
+        kwargs = mock_request_cls.call_args[1]
+        self.assertEqual(kwargs['params'], {'sap-client': '100'})
+
+
+class TestHTTPClientExecuteWithSession(unittest.TestCase):
+
+    def _make_client(self, **kwargs):
+        defaults = dict(host='example.com', user='SAP*', password='pass', client='100')
+        defaults.update(kwargs)
+        return HTTPClient(**defaults)
+
+    def test_returns_response_on_success(self):
+        client = self._make_client()
+        session = Mock()
+
+        response = Mock()
+        response.status_code = 200
+        client.retrieve = Mock(return_value=(Mock(), response))
+
+        result = client.execute_with_session(session, 'GET', 'path')
+
+        self.assertIs(result, response)
+
+    def test_calls_retrieve_with_all_params(self):
+        client = self._make_client()
+        session = Mock()
+
+        response = Mock()
+        response.status_code = 200
+        client.retrieve = Mock(return_value=(Mock(), response))
+
+        client.execute_with_session(session, 'POST', 'path',
+                                    params={'p': '1'}, headers={'h': 'v'}, body='data')
+
+        client.retrieve.assert_called_once_with(
+            session, 'POST', 'path',
+            params={'p': '1'}, headers={'h': 'v'}, body='data'
+        )
+
+    def test_error_handler_called_on_error_status(self):
+        client = self._make_client()
+        session = Mock()
+
+        req = Mock()
+        response = Mock()
+        response.status_code = 500
+        client.retrieve = Mock(return_value=(req, response))
+
+        with self.assertRaises(HTTPRequestError):
+            client.execute_with_session(session, 'GET', 'path')
+
+    def test_unauthorized_on_401(self):
+        client = self._make_client()
+        session = Mock()
+
+        req = Mock()
+        response = Mock()
+        response.status_code = 401
+        client.retrieve = Mock(return_value=(req, response))
+
+        with self.assertRaises(UnauthorizedError):
+            client.execute_with_session(session, 'GET', 'path')
+
+    def test_csrf_refetch_on_403_without_fetch_header(self):
+        client = self._make_client(login_method='HEAD', login_path='login')
+        session = MagicMock()
+        session.headers = {'x-csrf-token': 'old-token'}
+
+        req_first = Mock()
+        res_403 = Mock()
+        res_403.status_code = 403
+
+        login_req = Mock()
+        login_res = Mock()
+        login_res.status_code = 200
+        login_res.headers = {'x-csrf-token': 'new-token'}
+
+        req_retry = Mock()
+        res_ok = Mock()
+        res_ok.status_code = 200
+
+        call_count = [0]
+        retrieve_returns = [
+            (req_first, res_403),
+            (login_req, login_res),
+            (req_retry, res_ok),
+        ]
+
+        def fake_retrieve(sess, method, path, params=None, headers=None, body=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            return retrieve_returns[idx]
+
+        client.retrieve = fake_retrieve
+
+        result = client.execute_with_session(session, 'GET', 'path')
+
+        self.assertIs(result, res_ok)
+        self.assertEqual(session.headers['x-csrf-token'], 'new-token')
+
+    def test_no_csrf_refetch_when_header_is_fetch(self):
+        """403 with x-csrf-token: Fetch header should NOT trigger refetch."""
+        client = self._make_client()
+        session = Mock()
+
+        req = Mock()
+        response = Mock()
+        response.status_code = 403
+        client.retrieve = Mock(return_value=(req, response))
+
+        with self.assertRaises(HTTPRequestError):
+            client.execute_with_session(session, 'GET', 'path',
+                                        headers={'x-csrf-token': 'Fetch'})
+
+        # retrieve should be called exactly once - no refetch
+        client.retrieve.assert_called_once()
+
+    def test_no_csrf_refetch_for_non_403_errors(self):
+        """Non-403 errors should go straight to error handler."""
+        client = self._make_client()
+        session = Mock()
+
+        req = Mock()
+        response = Mock()
+        response.status_code = 500
+        client.retrieve = Mock(return_value=(req, response))
+
+        with self.assertRaises(HTTPRequestError):
+            client.execute_with_session(session, 'GET', 'path')
+
+        client.retrieve.assert_called_once()
+
+    def test_no_error_on_status_below_400(self):
+        client = self._make_client()
+        session = Mock()
+
+        for status in [200, 201, 204, 301, 302, 399]:
+            response = Mock()
+            response.status_code = status
+            client.retrieve = Mock(return_value=(Mock(), response))
+
+            result = client.execute_with_session(session, 'GET', 'path')
+            self.assertIs(result, response)
+
+    def test_csrf_refetch_with_empty_headers(self):
+        """403 with no headers at all should trigger CSRF refetch."""
+        client = self._make_client(login_method='HEAD', login_path='login')
+        session = MagicMock()
+        session.headers = {}
+
+        res_403 = Mock()
+        res_403.status_code = 403
+
+        login_res = Mock()
+        login_res.status_code = 200
+        login_res.headers = {'x-csrf-token': 'new-token'}
+
+        res_ok = Mock()
+        res_ok.status_code = 200
+
+        call_count = [0]
+        retrieve_returns = [
+            (Mock(), res_403),
+            (Mock(), login_res),
+            (Mock(), res_ok),
+        ]
+
+        def fake_retrieve(sess, method, path, params=None, headers=None, body=None):
+            idx = call_count[0]
+            call_count[0] += 1
+            return retrieve_returns[idx]
+
+        client.retrieve = fake_retrieve
+
+        result = client.execute_with_session(session, 'GET', 'path', headers=None)
+
+        self.assertIs(result, res_ok)
+
+
+class TestHTTPClientBuildSession(unittest.TestCase):
+
+    def _make_client(self, **kwargs):
+        defaults = dict(host='example.com', user='SAP*', password='pass', client='100',
+                        login_path='login', login_method='HEAD')
+        defaults.update(kwargs)
+        return HTTPClient(**defaults)
+
+    @patch('sap.http.client.requests.Session')
+    def test_build_session_default_verify(self, mock_session_cls):
+        client = self._make_client()
+
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_session_cls.return_value = mock_session
+
+        login_response = Mock()
+        login_response.status_code = 200
+        login_response.headers = {'x-csrf-token': 'token123'}
+        client.execute_with_session = Mock(return_value=login_response)
+
+        session, response = client.build_session()
+
+        self.assertIs(session, mock_session)
+        self.assertIs(response, login_response)
+        # verify not explicitly set when no ssl_server_cert and ssl_verify is not False
+        mock_session_cls.assert_called_once()
+
+    @patch('sap.http.client.requests.Session')
+    def test_build_session_with_ssl_server_cert(self, mock_session_cls):
+        client = self._make_client(ssl_server_cert='/path/to/ca.pem')
+
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_session_cls.return_value = mock_session
+
+        login_response = Mock()
+        login_response.status_code = 200
+        login_response.headers = {'x-csrf-token': 'token123'}
+        client.execute_with_session = Mock(return_value=login_response)
+
+        session, response = client.build_session()
+
+        self.assertEqual(mock_session.verify, '/path/to/ca.pem')
+
+    @patch('sap.http.client.requests.Session')
+    def test_build_session_with_verify_false(self, mock_session_cls):
+        client = self._make_client(verify=False)
+
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_session_cls.return_value = mock_session
+
+        login_response = Mock()
+        login_response.status_code = 200
+        login_response.headers = {'x-csrf-token': 'token123'}
+        client.execute_with_session = Mock(return_value=login_response)
+
+        session, response = client.build_session()
+
+        self.assertFalse(mock_session.verify)
+
+    @patch('sap.http.client.requests.Session')
+    def test_build_session_ssl_server_cert_precedence_over_verify_false(self, mock_session_cls):
+        client = self._make_client(verify=False, ssl_server_cert='/path/to/ca.pem')
+
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_session_cls.return_value = mock_session
+
+        login_response = Mock()
+        login_response.status_code = 200
+        login_response.headers = {'x-csrf-token': 'token123'}
+        client.execute_with_session = Mock(return_value=login_response)
+
+        session, response = client.build_session()
+
+        self.assertEqual(mock_session.verify, '/path/to/ca.pem')
+
+    @patch('sap.http.client.requests.Session')
+    def test_build_session_sets_csrf_token(self, mock_session_cls):
+        client = self._make_client()
+
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_session_cls.return_value = mock_session
+
+        login_response = Mock()
+        login_response.status_code = 200
+        login_response.headers = {'x-csrf-token': 'the-csrf-token'}
+        client.execute_with_session = Mock(return_value=login_response)
+
+        session, response = client.build_session()
+
+        self.assertEqual(mock_session.headers['x-csrf-token'], 'the-csrf-token')
+
+    @patch('sap.http.client.requests.Session')
+    def test_build_session_no_csrf_token_in_response(self, mock_session_cls):
+        client = self._make_client()
+
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_session_cls.return_value = mock_session
+
+        login_response = Mock()
+        login_response.status_code = 200
+        login_response.headers = {}
+        client.execute_with_session = Mock(return_value=login_response)
+
+        session, response = client.build_session()
+
+        self.assertNotIn('x-csrf-token', mock_session.headers)
+
+    @patch('sap.http.client.requests.Session')
+    def test_build_session_sets_auth(self, mock_session_cls):
+        client = self._make_client()
+
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_session_cls.return_value = mock_session
+
+        login_response = Mock()
+        login_response.status_code = 200
+        login_response.headers = {'x-csrf-token': 'token'}
+        client.execute_with_session = Mock(return_value=login_response)
+
+        session, _ = client.build_session()
+
+        self.assertEqual(mock_session.auth, client._auth)
+
+    @patch('sap.http.client.requests.Session')
+    def test_build_session_login_request(self, mock_session_cls):
+        client = self._make_client(login_path='my/login', login_method='GET')
+
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_session_cls.return_value = mock_session
+
+        login_response = Mock()
+        login_response.status_code = 200
+        login_response.headers = {'x-csrf-token': 'token'}
+        client.execute_with_session = Mock(return_value=login_response)
+
+        client.build_session()
+
+        client.execute_with_session.assert_called_once_with(
+            mock_session, 'GET', 'my/login', headers={'x-csrf-token': 'Fetch'}
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_sap_http_errors.py
+++ b/test/unit/test_sap_http_errors.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+
+import unittest
+from unittest.mock import Mock
+
+from sap.errors import SAPCliError
+
+from sap.http.errors import (
+    UnexpectedResponseContent,
+    HTTPRequestError,
+    UnauthorizedError,
+    TimedOutRequestError,
+)
+
+
+class TestUnexpectedResponseContent(unittest.TestCase):
+
+    def test_is_sapcli_error(self):
+        error = UnexpectedResponseContent('application/xml', 'text/html', '<html/>')
+        self.assertIsInstance(error, SAPCliError)
+
+    def test_attributes(self):
+        error = UnexpectedResponseContent('application/xml', 'text/html', '<html/>')
+
+        self.assertEqual(error.expected, 'application/xml')
+        self.assertEqual(error.received, 'text/html')
+        self.assertEqual(error.content, '<html/>')
+
+    def test_str(self):
+        error = UnexpectedResponseContent('application/xml', 'text/html', '<html/>')
+
+        self.assertEqual(str(error), 'Unexpected Content-Type: text/html with: <html/>')
+
+    def test_str_empty_content(self):
+        error = UnexpectedResponseContent('application/json', 'text/plain', '')
+
+        self.assertEqual(str(error), 'Unexpected Content-Type: text/plain with: ')
+
+
+class TestHTTPRequestError(unittest.TestCase):
+
+    def _make_error(self, status_code, text):
+        request = Mock()
+        response = Mock()
+        response.status_code = status_code
+        response.text = text
+        return HTTPRequestError(request, response)
+
+    def test_is_sapcli_error(self):
+        error = self._make_error(500, 'fail')
+        self.assertIsInstance(error, SAPCliError)
+
+    def test_attributes(self):
+        request = Mock()
+        response = Mock()
+        response.status_code = 403
+
+        error = HTTPRequestError(request, response)
+
+        self.assertIs(error.request, request)
+        self.assertIs(error.response, response)
+        self.assertEqual(error.status_code, 403)
+
+    def test_repr_with_header_and_message(self):
+        html = (
+            '<p class="errorTextHeader"> <span >403 Forbidden</span> </p>\n'
+            '<p class="detailText"> <span id="msgText">Access denied.</span></p>\n'
+        )
+        error = self._make_error(403, html)
+
+        self.assertEqual(repr(error), '403 Forbidden\nAccess denied.')
+
+    def test_str_delegates_to_repr(self):
+        html = (
+            '<p class="errorTextHeader"> <span >403 Forbidden</span> </p>\n'
+            '<p class="detailText"> <span id="msgText">Access denied.</span></p>\n'
+        )
+        error = self._make_error(403, html)
+
+        self.assertEqual(str(error), repr(error))
+
+    def test_repr_no_error_header(self):
+        html = '<p class="detailText"> <span id="msgText">Some error.</span></p>'
+        error = self._make_error(500, html)
+
+        self.assertEqual(repr(error), '500\n' + html)
+
+    def test_repr_no_error_message(self):
+        html = '<p class="errorTextHeader"> <span >500 Server Error</span> </p>'
+        error = self._make_error(500, html)
+
+        self.assertEqual(repr(error), '500\n' + html)
+
+    def test_repr_plain_text_response(self):
+        error = self._make_error(500, 'Internal Server Error')
+
+        self.assertEqual(repr(error), '500\nInternal Server Error')
+
+    def test_repr_filters_server_time(self):
+        html = (
+            '<p class="errorTextHeader"> <span >403 Forbidden</span> </p>\n'
+            '<p class="detailText"> <span id="msgText">Blocked by UCON.</span></p>\n'
+            '<p class="detailText"> <span id="msgText">Server time: 2022-07-25</span></p>\n'
+        )
+        error = self._make_error(403, html)
+
+        self.assertEqual(repr(error), '403 Forbidden\nBlocked by UCON.')
+
+    def test_repr_multiline_error_message(self):
+        html = (
+            '<p class="errorTextHeader"> <span >403 Forbidden</span> </p>\n'
+            '<p class="detailText"> <span id="msgText">Line one\nLine two.</span></p>\n'
+        )
+        error = self._make_error(403, html)
+
+        self.assertEqual(repr(error), '403 Forbidden\nLine one Line two.')
+
+    def test_repr_multiple_detail_messages(self):
+        html = (
+            '<p class="errorTextHeader"> <span >403 Forbidden</span> </p>\n'
+            '<p class="detailText"> <span id="msgText">First error.</span></p>\n'
+            '<p class="detailText"> <span id="msgText">Second error.</span></p>\n'
+        )
+        error = self._make_error(403, html)
+
+        self.assertEqual(repr(error), '403 Forbidden\nFirst error.\nSecond error.')
+
+    def test_repr_only_server_time_messages(self):
+        """When all detail messages are Server time entries, error_msg is empty."""
+        html = (
+            '<p class="errorTextHeader"> <span >403 Forbidden</span> </p>\n'
+            '<p class="detailText"> <span id="msgText">Server time: 2022-07-25</span></p>\n'
+        )
+        error = self._make_error(403, html)
+
+        self.assertEqual(repr(error), '403\n' + html)
+
+    def test_repr_empty_response_text(self):
+        error = self._make_error(500, '')
+
+        self.assertEqual(repr(error), '500\n')
+
+
+class TestUnauthorizedError(unittest.TestCase):
+
+    def _make_error(self):
+        request = Mock()
+        request.method = 'GET'
+        request.url = 'https://example.com/sap/bc/adt'
+        response = Mock()
+        response.status_code = 401
+        return UnauthorizedError(request, response, 'SAP*'), request, response
+
+    def test_is_sapcli_error(self):
+        error, _, _ = self._make_error()
+        self.assertIsInstance(error, SAPCliError)
+
+    def test_attributes(self):
+        error, request, response = self._make_error()
+
+        self.assertIs(error.request, request)
+        self.assertIs(error.response, response)
+        self.assertEqual(error.status_code, 401)
+        self.assertEqual(error.method, 'GET')
+        self.assertEqual(error.url, 'https://example.com/sap/bc/adt')
+        self.assertEqual(error.user, 'SAP*')
+
+    def test_repr(self):
+        error, _, _ = self._make_error()
+
+        self.assertEqual(repr(error), 'Authorization for the user "SAP*" has failed: GET https://example.com/sap/bc/adt')
+
+    def test_str_delegates_to_repr(self):
+        error, _, _ = self._make_error()
+
+        self.assertEqual(str(error), repr(error))
+
+
+class TestTimedOutRequestError(unittest.TestCase):
+
+    def _make_error(self):
+        request = Mock()
+        request.method = 'POST'
+        request.url = 'https://example.com/sap/bc/adt'
+        return TimedOutRequestError(request, 30), request
+
+    def test_is_sapcli_error(self):
+        error, _ = self._make_error()
+        self.assertIsInstance(error, SAPCliError)
+
+    def test_attributes(self):
+        error, request = self._make_error()
+
+        self.assertIs(error.request, request)
+        self.assertEqual(error.method, 'POST')
+        self.assertEqual(error.url, 'https://example.com/sap/bc/adt')
+        self.assertEqual(error.timeout, 30)
+
+    def test_repr(self):
+        error, _ = self._make_error()
+
+        self.assertEqual(repr(error), 'The request POST https://example.com/sap/bc/adt took more than 30s')
+
+    def test_str_delegates_to_repr(self):
+        error, _ = self._make_error()
+
+        self.assertEqual(str(error), repr(error))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Factor out HTTP tooling into a new module sap/http which should be used by all ADT, REST, and OData. This pull request ports ADT connection to the new HTTPClient.