### PR TITLE
tree-wide: add support for domains

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -12,13 +12,22 @@ in Python classes, the classes must inherit their metaclass from OrderedClassMem
 Top ADT objects such as ABAP Class or ABAP Function Module should inherit from ADTObject.
 Helper ADT objects (members of the top adt objects can just specify their metaclass=OrderedClassMembers).
 
-ADTObject childern must define class level object OBJTYPE which must be compatible with ADTObjectType.
+ADTObject children must define class level object OBJTYPE which must be compatible with ADTObjectType.
 
 Top ADT objects must declare their metadata stored in the class ADTCoreData.
 
 The corresponding Python code is stored in the directory sap/adt/
 
-# Functions
+## ADT object anatomy
+
+Objects metadata such as `Master Language` is accessible via the property
+`ADTObject.coredata` which returns an instance of `ADTCoreData`.
+
+The authoritative package information for the give object is accessible via the
+property `ADTOjbect.coredata.package_reference` which returns an instance of
+`ADTCoreData.Reference`.
+
+### Functions
 
 ABAP function modules s are organized in function groups which are something
 like directories of function modules.

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -23,9 +23,10 @@
 21. [rap](commands/businessservice.md) - RAP Business Services
 22. [strust](commands/strust.md) - SSL Certificates
 23. [dataelement](commands/dataelement.md) - ABAP DDIC Data Elements
-24. [structure](commands/structure.md) - ABAP DDIC structures
-25. [table](commands/table.md) - ABAP DDIC transparent tables
-26. [badi](commands/badi.md) - New style (Enhancements) BAdI operations
-27. [featuretoggle](commands/featuretoggles.md) - Feature Toggles
-28. [authorizations](commands/authorizations.md) - Authorization Fields, Objects, Transactions, and Defaults
-29. [abap](commands/abap.md) - ABAP utilities like run or find
+24. [domain](commands/domain.md) - ABAP DDIC Domains
+25. [structure](commands/structure.md) - ABAP DDIC structures
+26. [table](commands/table.md) - ABAP DDIC transparent tables
+27. [badi](commands/badi.md) - New style (Enhancements) BAdI operations
+28. [featuretoggle](commands/featuretoggles.md) - Feature Toggles
+29. [authorizations](commands/authorizations.md) - Authorization Fields, Objects, Transactions, and Defaults
+30. [abap](commands/abap.md) - ABAP utilities like run or find

--- a/doc/commands/dataelement.md
+++ b/doc/commands/dataelement.md
@@ -2,6 +2,7 @@
 
 - [Data Element](#data-element)
 	- [define](#define)
+	- [read](#read)
 	- [delete](#delete)
 	- [whereused](#whereused)
 
@@ -26,6 +27,135 @@ sapcli dataelement define DATA_ELEMENT_NAME --type=domain|predefinedAbapType [--
 * _--corrnr TRANSPORT_ specifies CTS Transport Request Number **(optional)**
 * _--activate_ activate after finishing the data element modification **(optional)**
 * _--no-error-existing_ do not fail if data element already exists **(optional)**
+
+## read
+
+Read and display a Data Element and its properties.
+
+```bash
+sapcli dataelement read DATA_ELEMENT_NAME [--format=ABAP|HUMAN]
+```
+
+* _DATA\_ELEMENT\_NAME_ specifying the name of the data element
+* _--format_ output format for the data element details **(optional, default: HUMAN)**
+  - `HUMAN` - human-readable format with labeled fields. For domain-based data elements, domain details are automatically included inline.
+  - `ABAP` - ABAP-compatible JSON format for programmatic processing
+
+**Example (HUMAN format - default):**
+
+```bash
+sapcli dataelement read Z_MY_DATAELEMENT
+```
+
+**Output (predefined ABAP type):**
+
+```text
+Data Element: Z_MY_DATAELEMENT
+Description: My custom data element
+Package: ZTEST
+Master Language: EN
+
+Definition:
+  Type
+    Kind: predefinedAbapType
+    Name: CHAR
+    Length: 10
+    Decimals: 0
+
+  Labels:
+    Short: Short Lbl
+    Medium: Medium Label
+    Long: Long Label Text
+    Heading: Heading Label Text
+```
+
+**Output (domain-based type):**
+
+```text
+Data Element: Z_MY_DATAELEMENT
+Description: My custom data element based on domain
+Package: ZTEST
+Master Language: EN
+
+Definition:
+  Type
+    Kind: domain
+    Name: ZMYDOMAIN
+    Description: Custom Domain
+
+    Type Information:
+        Datatype: CHAR
+        Length: 10
+    Output Information:
+        Length: 10
+    Value Information:
+        Fix Values:
+            - A: Option A
+            - B: Option B
+
+  Labels:
+    Short: Short Lbl
+    Medium: Medium Label
+    Long: Long Label Text
+    Heading: Heading Label Text
+```
+
+**Example (ABAP format):**
+
+```bash
+sapcli dataelement read Z_MY_DATAELEMENT --format=ABAP
+```
+
+**Output (predefined ABAP type):**
+
+```json
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "My custom data element",
+    "originalLanguage": "en"
+  },
+  "definition": {
+    "typeKind": "predefinedAbapType",
+    "dataType": "CHAR",
+    "length": 10,
+    "decimals": 0
+  },
+  "labels": {
+    "short": "Short Lbl",
+    "medium": "Medium Label",
+    "long": "Long Label Text",
+    "heading": "Heading Label Text"
+  }
+}
+```
+
+**Output (domain-based type):**
+
+```json
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "My custom data element based on domain",
+    "originalLanguage": "en"
+  },
+  "definition": {
+    "typeKind": "domain",
+    "domainName": "ZMYDOMAIN"
+  },
+  "labels": {
+    "short": "Short Lbl",
+    "medium": "Medium Label",
+    "long": "Long Label Text",
+    "heading": "Heading Label Text"
+  }
+}
+```
+
+**Note:**
+- For domain-based data elements in HUMAN format, domain details (type information, output characteristics, fixed values) are automatically displayed inline.
+- ABAP format includes only the data element definition without embedded domain details.
+- If a domain cannot be fetched (e.g., doesn't exist or network error), a warning is printed to stderr, and the command continues without domain details.
 
 ## delete
 

--- a/doc/commands/domain.md
+++ b/doc/commands/domain.md
@@ -1,0 +1,155 @@
+# Domain
+
+ABAP Domains define elementary data types and their technical characteristics (data type, length, value range). Domains can be referenced by data elements.
+
+- [create](#create) ⚠️ *Disabled - Not Supported*
+- [read](#read)
+- [write](#write) ⚠️ *Disabled - Not Supported*
+- [activate](#activate)
+- [delete](#delete) ⚠️ *Disabled - Not Supported*
+- [whereused](#whereused)
+
+## create
+
+⚠️ **This command is currently disabled.**
+
+Creating domains is not supported because this operation is dangerous and has not been tested.
+
+```bash
+sapcli domain create DOMAIN_NAME DESCRIPTION PACKAGE
+```
+
+**Note:** Attempting to use this command will result in an error: "Create Domain is not supported."
+
+## read
+
+Read and display a Domain and its properties.
+
+```bash
+sapcli domain read DOMAIN_NAME [--format=ABAP|HUMAN]
+```
+
+* _DOMAIN\_NAME_ specifying the name of the domain (e.g., BEGRM, CHAR20)
+* _--format_ output format for the domain details **(optional, default: ABAP)**
+  - `ABAP` - ABAP-compatible JSON format for programmatic processing
+  - `HUMAN` - human-readable format with labeled fields
+
+**Example (ABAP format - default):**
+
+```bash
+sapcli domain read BEGRM
+```
+
+**Output:**
+
+```json
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "Authorization group in the material master",
+    "originalLanguage": "en"
+  },
+  "format": {
+    "dataType": "CHAR",
+    "length": 4
+  },
+  "outputCharacteristics": {
+    "length": 4
+  },
+  "fixedValues": [
+    {
+      "fixedValue": "H",
+      "description": "History"
+    },
+    {
+      "fixedValue": "X",
+      "description": "Xml"
+    }
+  ]
+}
+```
+
+**Example (HUMAN format):**
+
+```bash
+sapcli domain read BEGRM --format=HUMAN
+```
+
+**Output:**
+
+```text
+Domain: BEGRM
+Description: Authorization group in the material master
+Package: MGA
+Master Language: EN
+
+Content:
+    Type Information:
+        Datatype: CHAR
+        Length: 4
+    Output Information:
+        Length: 4
+    Value Information:
+        Table Reference: TMBG
+        Fix Values:
+            - H: History
+            - X: Xml
+```
+
+## write
+
+⚠️ **This command is currently disabled.**
+
+Writing to domains is not supported because this operation is dangerous and has not been tested.
+
+```bash
+sapcli domain write DOMAIN_NAME SOURCE [SOURCE ...]
+```
+
+**Note:** Attempting to use this command will result in an error: "Write Domain is not supported."
+
+## activate
+
+Activate the given domain.
+
+```bash
+sapcli domain activate DOMAIN_NAME [DOMAIN_NAME ...] [--ignore-errors] [--warning-errors]
+```
+
+* _DOMAIN\_NAME_ one or more domain names to activate
+* _--ignore-errors_ do not stop activation in case of errors **(optional)**
+* _--warning-errors_ treat activation warnings as errors **(optional)**
+
+**Example:**
+
+```bash
+sapcli domain activate BEGRM CHAR20
+```
+
+## delete
+
+⚠️ **This command is currently disabled.**
+
+Deleting domains is not supported because this operation is dangerous and has not been tested.
+
+```bash
+sapcli domain delete DOMAIN_NAME [DOMAIN_NAME ...]
+```
+
+**Note:** Attempting to use this command will result in an error: "Delete Domain is not supported."
+
+## whereused
+
+Find objects that reference the given domain.
+
+```bash
+sapcli domain whereused DOMAIN_NAME
+```
+
+* _DOMAIN\_NAME_ specifying the name of the domain
+
+**Example:**
+
+```bash
+sapcli domain whereused BEGRM
+```

--- a/sap/adt/__init__.py
+++ b/sap/adt/__init__.py
@@ -15,5 +15,6 @@ from sap.adt.table import Table  # noqa: F401
 from sap.adt.enhancement_implementation import EnhancementImplementation  # noqa: F401
 from sap.adt.structure import Structure  # noqa: F401
 from sap.adt.dataelement import DataElement  # noqa: F401
+from sap.adt.domain import Domain  # noqa: F401
 from sap.adt.authorization_field import AuthorizationField  # noqa: F401
 from sap.adt.whereused import where_used, get_scope, get_where_used  # noqa: F401

--- a/sap/adt/core.py
+++ b/sap/adt/core.py
@@ -82,7 +82,8 @@ def _get_collection_accepts(discovery_xml):
 
 def _adt_http_error_handler(client, req, res):  # pylint: disable=unused-argument
 
-    if res.headers['content-type'] == 'application/xml':
+    content_type = res.headers.get('content-type', '').lower().split(';')[0].strip()
+    if content_type == 'application/xml':
         error = new_adt_error_from_xml(res.text)
 
         if error is not None:

--- a/sap/adt/domain.py
+++ b/sap/adt/domain.py
@@ -1,0 +1,92 @@
+"""ABAP Domain ADT functionality module"""
+
+# pylint: disable=too-few-public-methods
+
+from sap.adt.objects import ADTObject, ADTObjectType
+from sap.adt.annotations import (
+    OrderedClassMembers,
+    xml_text_node_property,
+    XmlNodeProperty,
+    XmlListNodeProperty,
+    XmlNodeAttributeProperty,
+)
+from sap.adt.objects import XMLNamespace, XMLNS_ADTCORE
+
+XMLNS_DOMA = XMLNamespace('doma', 'http://www.sap.com/dictionary/domain', parents=[XMLNS_ADTCORE])
+
+
+class DomainTypeInformation(metaclass=OrderedClassMembers):
+    """Domain type information"""
+
+    datatype = xml_text_node_property('doma:datatype')
+    length = xml_text_node_property('doma:length')
+    decimals = xml_text_node_property('doma:decimals')
+
+
+class DomainOutputInformation(metaclass=OrderedClassMembers):
+    """Domain output information"""
+
+    length = xml_text_node_property('doma:length')
+    style = xml_text_node_property('doma:style')
+    conversion_exit = xml_text_node_property('doma:conversionExit')
+    sign_exists = xml_text_node_property('doma:signExists')
+    lowercase = xml_text_node_property('doma:lowercase')
+    ampm_format = xml_text_node_property('doma:ampmFormat')
+
+
+class DomainFixValue(metaclass=OrderedClassMembers):
+    """Domain fixed value"""
+
+    position = xml_text_node_property('doma:position')
+    low = xml_text_node_property('doma:low')
+    high = xml_text_node_property('doma:high')
+    text = xml_text_node_property('doma:text')
+
+
+class DomainValueTableRef(metaclass=OrderedClassMembers):
+    """Domain value table reference"""
+
+    name = XmlNodeAttributeProperty('adtcore:name')
+    uri = XmlNodeAttributeProperty('adtcore:uri')
+    typ = XmlNodeAttributeProperty('adtcore:type')
+
+
+class DomainValueInformation(metaclass=OrderedClassMembers):
+    """Domain value information"""
+
+    value_table_ref = XmlNodeProperty('doma:valueTableRef', factory=DomainValueTableRef)
+    append_exists = xml_text_node_property('doma:appendExists')
+    fix_values = XmlListNodeProperty('doma:fixValues/doma:fixValue', factory=DomainFixValue)
+
+
+class DomainContent(metaclass=OrderedClassMembers):
+    """Domain content"""
+
+    type_information = XmlNodeProperty('doma:typeInformation', factory=DomainTypeInformation)
+    output_information = XmlNodeProperty('doma:outputInformation', factory=DomainOutputInformation)
+    value_information = XmlNodeProperty('doma:valueInformation', factory=DomainValueInformation)
+
+
+class Domain(ADTObject):
+    """ABAP Domain"""
+
+    OBJTYPE = ADTObjectType(
+        'DOMA/DD',
+        'ddic/domains',
+        XMLNS_DOMA,
+        'application/vnd.sap.adt.domains.v2+xml',
+        {'application/vnd.sap.adt.domains.v2+xml': ''},
+        'domain',
+        editor_factory=None
+    )
+
+    content = XmlNodeProperty('doma:content', factory=DomainContent)
+
+    def __init__(self, connection, name, package=None, metadata=None):
+        super().__init__(connection, name, metadata, active_status='active')
+
+        self._metadata.package_reference.name = package
+        self.content = DomainContent()
+        self.content.type_information = DomainTypeInformation()
+        self.content.output_information = DomainOutputInformation()
+        self.content.value_information = DomainValueInformation()

--- a/sap/adt/objects.py
+++ b/sap/adt/objects.py
@@ -2,7 +2,7 @@
 """Objects ADT functionality module"""
 
 import re
-from typing import NamedTuple, Union, List, cast
+from typing import NamedTuple, Optional, Union, List, cast
 from urllib.parse import quote_plus
 
 from sap.adt.core import mod_log
@@ -251,17 +251,17 @@ class ADTCoreData:
     class Reference(metaclass=OrderedClassMembers):
         """ADT Reference by Name"""
 
-        def __init__(self, name=None):
+        def __init__(self, name: str | None = None):
             self._name = None if name is None else name.upper()
 
         @xml_attribute('adtcore:name')
-        def name(self):
+        def name(self) -> str | None:
             """Returns reference name """
 
             return self._name
 
         @name.setter
-        def name(self, value):
+        def name(self, value: str | None):
             """Sets reference name"""
 
             self._name = None if value is None else value.upper()
@@ -269,19 +269,22 @@ class ADTCoreData:
     # pylint: disable=too-many-arguments
     def __init__(self, package=None, description=None, language=None,
                  master_language=None, master_system=None, responsible=None,
-                 package_reference=None, abap_language_version=None):
+                 package_reference: str | None = None, abap_language_version=None):
         self._package = package
         self._description = description
         self._language = language
         self._master_language = master_language
         self._master_system = master_system
         self._responsible = responsible
-        self._package_reference = ADTCoreData.Reference(name=package_reference)
+        self._package_reference: ADTCoreData.Reference | None = ADTCoreData.Reference(name=package_reference)
         self._abap_language_version = abap_language_version
 
     @property
     def package(self):
-        """ABAP development package (DEVC)"""
+        """ABAP development package (DEVC)
+
+        This property is not populated by ADT response.
+        """
 
         return self._package
 
@@ -358,13 +361,13 @@ class ADTCoreData:
         self._responsible = value
 
     @property
-    def package_reference(self):
-        """The object's package reference"""
+    def package_reference(self) -> Optional["ADTCoreData.Reference"]:
+        """The object's package reference as returned by ADT backend"""
 
         return self._package_reference
 
     @package_reference.setter
-    def package_reference(self, value):
+    def package_reference(self, value: Optional["ADTCoreData.Reference"]):
         """Set the object's package reference"""
 
         self._package_reference = value
@@ -510,7 +513,7 @@ class ADTObject(metaclass=OrderedClassMembers):
         return f'{self.objtype.code} {self.name}'
 
     @property
-    def coredata(self):
+    def coredata(self) -> ADTCoreData | None:
         """ADT Core Data"""
 
         return self._metadata
@@ -530,7 +533,11 @@ class ADTObject(metaclass=OrderedClassMembers):
 
     @property
     def package(self):
-        """ABAP development package"""
+        """ABAP development package. If you need authoritative
+           information about package where the object belongs, use
+           coredata.package_reference.name instead because the package property is not
+           populated by ADT response and is only for object's internal use.
+        """
 
         return self._metadata.package
 
@@ -656,7 +663,7 @@ class ADTObject(metaclass=OrderedClassMembers):
 
     @xml_element('adtcore:packageRef')
     def reference(self):
-        """The object's package reference"""
+        """The object's package reference, usually populated by ADT back-end response"""
 
         return self._metadata.package_reference
 

--- a/sap/cli/__init__.py
+++ b/sap/cli/__init__.py
@@ -53,6 +53,7 @@ class CommandsCache:
         import sap.cli.badi
         import sap.cli.structure
         import sap.cli.dataelement
+        import sap.cli.domain
         import sap.cli.authorizationfield
         import sap.cli.abap
         import sap.cli.config
@@ -81,6 +82,7 @@ class CommandsCache:
                 (adt_connection_from_args, sap.cli.table.CommandGroup()),
                 (adt_connection_from_args, sap.cli.structure.CommandGroup()),
                 (adt_connection_from_args, sap.cli.dataelement.CommandGroup()),
+                (adt_connection_from_args, sap.cli.domain.CommandGroup()),
                 (adt_connection_from_args, sap.cli.authorizationfield.CommandGroup()),
                 (adt_connection_from_args, sap.cli.checkin.CommandGroup()),
                 (adt_connection_from_args, sap.cli.badi.CommandGroup()),

--- a/sap/cli/dataelement.py
+++ b/sap/cli/dataelement.py
@@ -1,7 +1,10 @@
 """ADT proxy for ABAP DDIC Data Element"""
 
+import json
 from sap.errors import SAPCliError
 import sap.adt
+import sap.adt.domain
+import sap.cli.domain_formatter
 from sap.adt.dataelement import DataElementValidationIssues
 from sap.adt.errors import ExceptionResourceAlreadyExists
 import sap.cli.object
@@ -25,6 +28,135 @@ class CommandGroup(sap.cli.object.CommandGroupObjectMaster):
             package = args.package
 
         return sap.adt.DataElement(connection, name.upper(), package=package, metadata=metadata)
+
+    def define_read(self, commands):
+        """Add the argument --format=ABAP|HUMAN to the read command to allow users to choose the output format."""
+
+        read_cmd = super().define_read(commands)
+        read_cmd.append_argument(
+            '--format',
+            choices=['ABAP', 'HUMAN'],
+            default='HUMAN',
+            help='Output format for the Data Element details'
+        )
+        return read_cmd
+
+    def read_object_text(self, connection, args):
+        """Retrieves the Data Element and prints its details"""
+
+        console = args.console_factory()
+        obj = self.instance(connection, args.name, args)
+        obj.fetch()
+
+        if args.format == 'ABAP':
+            self._print_abap_format(console, obj)
+        else:
+            # Print the details of the Data Element in a human-readable format
+            self._print_human_format(console, obj, connection)
+
+    def _print_human_format(self, console, obj, connection):
+        """Print Data Element details in human-readable format"""
+
+        console.printout(f'Data Element: {obj.name}')
+        console.printout(f'Description: {obj.description}')
+        console.printout(f'Package: {obj.coredata.package_reference.name}')
+        console.printout('')
+        console.printout('Definition:')
+
+        # Type information with new nested structure
+        console.printout('  Type')
+        console.printout(f'    Kind: {obj.definition.typ or ""}')
+
+        if obj.definition.typ == 'domain':
+            console.printout(f'    Name: {obj.definition.typ_name or ""}')
+
+            # Always fetch and display domain details for domain-based elements in HUMAN format
+            if obj.definition.typ_name:
+                self._print_domain_inline(connection, obj.definition.typ_name, console)
+        elif obj.definition.typ == 'predefinedAbapType':
+            console.printout(f'    Name: {obj.definition.data_type or ""}')
+            console.printout(f'    Length: {obj.definition.data_type_length or "0"}')
+            console.printout(f'    Decimals: {obj.definition.data_type_decimals or "0"}')
+
+        # Labels
+        console.printout('')
+        console.printout('  Labels:')
+        console.printout(f'    Short: {obj.definition.label_short or ""}')
+        console.printout(f'    Medium: {obj.definition.label_medium or ""}')
+        console.printout(f'    Long: {obj.definition.label_long or ""}')
+        console.printout(f'    Heading: {obj.definition.label_heading or ""}')
+
+        # Additional properties
+        if obj.definition.search_help:
+            console.printout('')
+            console.printout('  Additional Properties:')
+            console.printout(f'    Search Help: {obj.definition.search_help}')
+            if obj.definition.search_help_parameter:
+                console.printout(f'    Search Help Parameter: {obj.definition.search_help_parameter}')
+
+    def _print_abap_format(self, console, obj):
+        """Print Data Element details in ABAP-compatible JSON format"""
+
+        output = {
+            'formatVersion': '1',
+            'header': {
+                'description': obj.description or '',
+                'originalLanguage': obj.coredata.master_language.lower()
+                if obj.coredata.master_language else ''
+            },
+            'definition': {
+                'typeKind': obj.definition.typ or ''
+            }
+        }
+
+        # Add type-specific information
+        if obj.definition.typ == 'domain':
+            output['definition']['domainName'] = obj.definition.typ_name or ''
+        elif obj.definition.typ == 'predefinedAbapType':
+            output['definition']['dataType'] = obj.definition.data_type or ''
+            output['definition']['length'] = int(obj.definition.data_type_length) \
+                if obj.definition.data_type_length else 0
+            output['definition']['decimals'] = int(obj.definition.data_type_decimals) \
+                if obj.definition.data_type_decimals else 0
+
+        # Add labels
+        output['labels'] = {
+            'short': obj.definition.label_short or '',
+            'medium': obj.definition.label_medium or '',
+            'long': obj.definition.label_long or '',
+            'heading': obj.definition.label_heading or ''
+        }
+
+        # Add search help if present
+        if obj.definition.search_help:
+            output['searchHelp'] = {
+                'name': obj.definition.search_help,
+                'parameter': obj.definition.search_help_parameter or ''
+            }
+
+        console.printout(json.dumps(output, indent=2))
+
+    def _print_domain_inline(self, connection, domain_name, console):
+        """Print domain information inline under Type section
+
+        Args:
+            connection: ADT connection
+            domain_name: Name of domain to fetch
+            console: Console for output
+        """
+
+        domain = sap.adt.Domain(connection, domain_name.upper())
+        try:
+            domain.fetch()
+        except SAPCliError as ex:
+            console.printerr(f'    Warning: Could not fetch domain {domain_name}: {str(ex)}')
+            return
+
+        console.printout(f'    Description: {domain.description}')
+        console.printout('')
+
+        # Use shared formatter with indentation to align under Type section
+        sap.cli.domain_formatter.format_domain_human(console, domain, indent='    ')
 
 
 @CommandGroup.argument_corrnr()

--- a/sap/cli/domain.py
+++ b/sap/cli/domain.py
@@ -3,6 +3,7 @@
 import json
 import sap.adt
 import sap.cli.object
+import sap.cli.domain_formatter
 from sap.errors import SAPCliError
 
 
@@ -63,52 +64,11 @@ class CommandGroup(sap.cli.object.CommandGroupObjectMaster):
         console.printout('')
         console.printout('Content:')
 
-        # Type Information
-        console.printout('    Type Information:')
-        console.printout(f'        Datatype: {obj.content.type_information.datatype}')
-        length = int(obj.content.type_information.length) if obj.content.type_information.length else 0
-        console.printout(f'        Length: {length}')
-
-        # Output Information
-        console.printout('    Output Information:')
-        out_length = int(obj.content.output_information.length) if obj.content.output_information.length else 0
-        console.printout(f'        Length: {out_length}')
-
-        # Value Information
-        console.printout('    Value Information:')
-        if obj.content.value_information.value_table_ref and obj.content.value_information.value_table_ref.name:
-            console.printout(f'        Table Reference: {obj.content.value_information.value_table_ref.name}')
-
-        if obj.content.value_information.fix_values:
-            console.printout('        Fix Values:')
-            for fix_value in obj.content.value_information.fix_values:
-                console.printout(f'            - {fix_value.low}: {fix_value.text}')
+        # Delegate to shared formatter
+        sap.cli.domain_formatter.format_domain_human(console, obj, indent='    ')
 
     def _print_abap_format(self, console, obj):
         """Print Domain details in ABAP-compatible JSON format"""
 
-        output = {
-            'formatVersion': '1',
-            'header': {
-                'description': obj.description or '',
-                'originalLanguage': obj._metadata.master_language.lower() if obj._metadata.master_language else ''
-            },
-            'format': {
-                'dataType': obj.content.type_information.datatype or '',
-                'length': int(obj.content.type_information.length) if obj.content.type_information.length else 0
-            },
-            'outputCharacteristics': {
-                'length': int(obj.content.output_information.length) if obj.content.output_information.length else 0
-            }
-        }
-
-        # Add fixed values if they exist
-        if obj.content.value_information.fix_values:
-            output['fixedValues'] = []
-            for fix_value in obj.content.value_information.fix_values:
-                output['fixedValues'].append({
-                    'fixedValue': fix_value.low or '',
-                    'description': fix_value.text or ''
-                })
-
+        output = sap.cli.domain_formatter.format_domain_abap(obj)
         console.printout(json.dumps(output, indent=2))

--- a/sap/cli/domain.py
+++ b/sap/cli/domain.py
@@ -1,0 +1,114 @@
+"""Command line interface for Domain ADT object."""
+
+import json
+import sap.adt
+import sap.cli.object
+from sap.errors import SAPCliError
+
+
+class CommandGroup(sap.cli.object.CommandGroupObjectMaster):
+    """Adapter converting command line parameters to sap.adt.Domain calls."""
+
+    def __init__(self):
+        super().__init__('domain')
+        self.define()
+
+    def instance(self, connection, name, args, metadata=None):
+        """Creates an instance of the Domain ADT object based on the provided parameters."""
+
+        return sap.adt.Domain(connection, name.upper(), metadata=metadata)
+
+    def define_read(self, commands):
+        """Add the argument --format=ABAP|HUMAN to the read command to allow users to choose the output format."""
+
+        read_cmd = super().define_read(commands)
+        read_cmd.append_argument(
+            '--format',
+            choices=['ABAP', 'HUMAN'],
+            default='ABAP',
+            help='Output format for the Domain details'
+        )
+        return read_cmd
+
+    def create_object(self, connection, args):
+        """Create is not supported for Domains"""
+        raise SAPCliError('Create Domain is not supported.')
+
+    def delete_object(self, connection, args):
+        """Delete is not supported for Domains"""
+        raise SAPCliError('Delete Domain is not supported.')
+
+    def write_object_text(self, connection, args):
+        """Write is not supported for Domains"""
+        raise SAPCliError('Write Domain is not supported.')
+
+    def read_object_text(self, connection, args):
+        """Retrieves the Domain and prints its details"""
+
+        console = args.console_factory()
+        obj = self.instance(connection, args.name, args)
+        obj.fetch()
+
+        if args.format == 'HUMAN':
+            self._print_human_format(console, obj)
+        else:  # ABAP format
+            self._print_abap_format(console, obj)
+
+    def _print_human_format(self, console, obj):
+        """Print Domain details in human-readable format"""
+
+        console.printout(f'Domain: {obj.name}')
+        console.printout(f'Description: {obj.description}')
+        console.printout(f'Package: {obj.coredata.package_reference.name}')
+        console.printout('')
+        console.printout('Content:')
+
+        # Type Information
+        console.printout('    Type Information:')
+        console.printout(f'        Datatype: {obj.content.type_information.datatype}')
+        length = int(obj.content.type_information.length) if obj.content.type_information.length else 0
+        console.printout(f'        Length: {length}')
+
+        # Output Information
+        console.printout('    Output Information:')
+        out_length = int(obj.content.output_information.length) if obj.content.output_information.length else 0
+        console.printout(f'        Length: {out_length}')
+
+        # Value Information
+        console.printout('    Value Information:')
+        if obj.content.value_information.value_table_ref and obj.content.value_information.value_table_ref.name:
+            console.printout(f'        Table Reference: {obj.content.value_information.value_table_ref.name}')
+
+        if obj.content.value_information.fix_values:
+            console.printout('        Fix Values:')
+            for fix_value in obj.content.value_information.fix_values:
+                console.printout(f'            - {fix_value.low}: {fix_value.text}')
+
+    def _print_abap_format(self, console, obj):
+        """Print Domain details in ABAP-compatible JSON format"""
+
+        output = {
+            'formatVersion': '1',
+            'header': {
+                'description': obj.description or '',
+                'originalLanguage': obj._metadata.master_language.lower() if obj._metadata.master_language else ''
+            },
+            'format': {
+                'dataType': obj.content.type_information.datatype or '',
+                'length': int(obj.content.type_information.length) if obj.content.type_information.length else 0
+            },
+            'outputCharacteristics': {
+                'length': int(obj.content.output_information.length) if obj.content.output_information.length else 0
+            }
+        }
+
+        # Add fixed values if they exist
+        if obj.content.value_information.fix_values:
+            output['fixedValues'] = []
+            for fix_value in obj.content.value_information.fix_values:
+                output['fixedValues'].append({
+                    'fixedValue': fix_value.low or '',
+                    'description': fix_value.text or ''
+                })
+
+        console.printout(json.dumps(output, indent=2))

--- a/sap/cli/domain_formatter.py
+++ b/sap/cli/domain_formatter.py
@@ -1,0 +1,67 @@
+"""Formatting utilities for Domain objects"""
+
+
+def format_domain_human(console, domain_obj, indent=''):
+    """Format domain information in human-readable format
+
+    Args:
+        console: Console object for output
+        domain_obj: sap.adt.Domain instance with fetched content
+        indent: String prefix for indentation (e.g., '    ' or '  ')
+    """
+    # Type Information
+    console.printout(f'{indent}Type Information:')
+    console.printout(f'{indent}    Datatype: {domain_obj.content.type_information.datatype}')
+    length = int(domain_obj.content.type_information.length) if domain_obj.content.type_information.length else 0
+    console.printout(f'{indent}    Length: {length}')
+
+    # Output Information
+    console.printout(f'{indent}Output Information:')
+    out_length = int(domain_obj.content.output_information.length) if domain_obj.content.output_information.length else 0
+    console.printout(f'{indent}    Length: {out_length}')
+
+    # Value Information
+    console.printout(f'{indent}Value Information:')
+    if domain_obj.content.value_information.value_table_ref and domain_obj.content.value_information.value_table_ref.name:
+        console.printout(f'{indent}    Table Reference: {domain_obj.content.value_information.value_table_ref.name}')
+
+    if domain_obj.content.value_information.fix_values:
+        console.printout(f'{indent}    Fix Values:')
+        for fix_value in domain_obj.content.value_information.fix_values:
+            console.printout(f'{indent}        - {fix_value.low}: {fix_value.text}')
+
+
+def format_domain_abap(domain_obj):
+    """Format domain information in ABAP-compatible JSON structure
+
+    Args:
+        domain_obj: sap.adt.Domain instance with fetched content
+
+    Returns:
+        dict: Formatted domain data ready for json.dumps()
+    """
+    output = {
+        'formatVersion': '1',
+        'header': {
+            'description': domain_obj.description or '',
+            'originalLanguage': domain_obj.coredata.master_language.lower() if domain_obj.coredata.master_language else ''
+        },
+        'format': {
+            'dataType': domain_obj.content.type_information.datatype or '',
+            'length': int(domain_obj.content.type_information.length) if domain_obj.content.type_information.length else 0
+        },
+        'outputCharacteristics': {
+            'length': int(domain_obj.content.output_information.length) if domain_obj.content.output_information.length else 0
+        }
+    }
+
+    # Add fixed values if they exist
+    if domain_obj.content.value_information.fix_values:
+        output['fixedValues'] = []
+        for fix_value in domain_obj.content.value_information.fix_values:
+            output['fixedValues'].append({
+                'fixedValue': fix_value.low or '',
+                'description': fix_value.text or ''
+            })
+
+    return output

--- a/sap/http/client.py
+++ b/sap/http/client.py
@@ -97,12 +97,21 @@ class HTTPClient():
 
         The handler will be called with the request and response objects
         when an error occurs.
+
+        The handler is supposed to either raise an exception or return None. If
+        it returns None, the next handler will be called. If no handler raises
+        an exception, the default behavior is to raise an HTTPRequestError.
         """
 
         self.error_handlers.insert(0, handler)
 
     def handle_http_error(self, req, res):
-        """Raise the correct exception based on response content."""
+        """Raise the correct exception based on response content.
+
+        Calls the error handlers in order until one of them raises an
+        exception. If no handler raises an exception, a HTTPRequestError is
+        raised.
+        """
 
         for handler in self.error_handlers:
             handler(self, req, res)
@@ -111,7 +120,12 @@ class HTTPClient():
         """Set the connection error handler for the client.
 
         The handler will be called with the client and error
-        when a connection error occurs.
+        when a requests.exceptions.ConnectionError occurs.
+
+        def my_connection_error_handler(client: sap.http.client.HTTPClient, error: requests.exceptions.ConnectionError):
+            # Handle the connection error, e.g. by logging it or raising a custom exception
+
+        If the handler does not raise an exception, the original ConnectionError will be re-raised.
         """
 
         self._connection_error_handler = handler

--- a/test/unit/fixtures_adt_dataelement.py
+++ b/test/unit/fixtures_adt_dataelement.py
@@ -185,3 +185,42 @@ ACTIVATE_DATA_ELEMENT_BODY = f'''<?xml version="1.0" encoding="UTF-8"?>
 </adtcore:objectReferences>'''
 
 ERROR_XML_DATA_ELEMENT_ALREADY_EXISTS=f'''<?xml version="1.0" encoding="utf-8"?><exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><namespace id="com.sap.adt"/><type id="ExceptionResourceAlreadyExists"/><message lang="EN">Resource Data Element {DATA_ELEMENT_NAME} does already exist.</message><localizedMessage lang="EN">Resource Package $SAPCLI_TEST_ROOT does already exist.</localizedMessage><properties/></exc:exception>'''
+
+# Domain ABC fixture for testing --expand feature
+DOMAIN_ABC_NAME = 'ABC'
+DOMAIN_ABC_ADT_GET_RESPONSE_XML = '''<?xml version="1.0" encoding="UTF-8"?>
+<doma:domain xmlns:doma="http://www.sap.com/dictionary/domain" adtcore:responsible="DEVELOPER" adtcore:masterLanguage="EN" adtcore:masterSystem="SAP" adtcore:abapLanguageVersion="standard" adtcore:name="ABC" adtcore:type="DOMA/DD" adtcore:changedAt="2023-09-12T10:00:00Z" adtcore:version="active" adtcore:changedBy="SAP" adtcore:createdBy="DEVELOPER" adtcore:description="Test Domain ABC" adtcore:language="EN" xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:packageRef adtcore:uri="/sap/bc/adt/packages/package" adtcore:type="DEVC/K" adtcore:name="PACKAGE"/>
+  <doma:content>
+    <doma:typeInformation>
+      <doma:datatype>CHAR</doma:datatype>
+      <doma:length>000010</doma:length>
+      <doma:decimals>000000</doma:decimals>
+    </doma:typeInformation>
+    <doma:outputInformation>
+      <doma:length>000010</doma:length>
+      <doma:style>00</doma:style>
+      <doma:conversionExit/>
+      <doma:signExists>false</doma:signExists>
+      <doma:lowercase>false</doma:lowercase>
+      <doma:ampmFormat>false</doma:ampmFormat>
+    </doma:outputInformation>
+    <doma:valueInformation>
+      <doma:appendExists>false</doma:appendExists>
+      <doma:fixValues>
+        <doma:fixValue>
+          <doma:position>0001</doma:position>
+          <doma:low>A</doma:low>
+          <doma:high/>
+          <doma:text>Option A</doma:text>
+        </doma:fixValue>
+        <doma:fixValue>
+          <doma:position>0002</doma:position>
+          <doma:low>B</doma:low>
+          <doma:high/>
+          <doma:text>Option B</doma:text>
+        </doma:fixValue>
+      </doma:fixValues>
+    </doma:valueInformation>
+  </doma:content>
+</doma:domain>'''

--- a/test/unit/fixtures_adt_domain.py
+++ b/test/unit/fixtures_adt_domain.py
@@ -1,0 +1,44 @@
+DOMAIN_NAME = 'BEGRM'
+
+DOMAIN_ADT_GET_RESPONSE_XML = '''<?xml version="1.0" encoding="UTF-8"?>
+<doma:domain xmlns:doma="http://www.sap.com/dictionary/domain" adtcore:responsible="DEVELOPER" adtcore:masterLanguage="EN" adtcore:masterSystem="SAP" adtcore:abapLanguageVersion="standard" adtcore:name="BEGRM" adtcore:type="DOMA/DD" adtcore:changedAt="2015-06-05T08:49:19Z" adtcore:version="active" adtcore:changedBy="SAP" adtcore:createdBy="DEVELOPER" adtcore:description="Authorization group in the material master" adtcore:language="EN" xmlns:adtcore="http://www.sap.com/adt/core">
+  <atom:link xmlns:atom="http://www.w3.org/2005/Atom" href="versions" rel="http://www.sap.com/adt/relations/versions" title="Historic versions"/>
+  <atom:link xmlns:atom="http://www.w3.org/2005/Atom" href="/sap/bc/adt/repository/informationsystem/abaplanguageversions?uri=%2Fsap%2Fbc%2Fadt%2Fddic%2Fdomains%2Fbegrm" rel="http://www.sap.com/adt/relations/informationsystem/abaplanguageversions" type="application/vnd.sap.adt.nameditems.v1+xml" title="Allowed ABAP language versions"/>
+  <atom:link xmlns:atom="http://www.w3.org/2005/Atom" href="/sap/bc/adt/vit/wb/object_type/domadd/object_name/BEGRM" rel="self" type="application/vnd.sap.sapgui" title="Representation in SAP Gui"/>
+  <atom:link xmlns:atom="http://www.w3.org/2005/Atom" href="/sap/bc/adt/vit/docu/object_type/do/object_name/begrm?masterLanguage=E&amp;mode=edit" rel="http://www.sap.com/adt/relations/documentation" type="application/vnd.sap.sapgui" title="Documentation"/>
+  <atom:link xmlns:atom="http://www.w3.org/2005/Atom" href="./begrm" rel="http://www.sap.com/adt/relations/source" type="text/html" title="Landing Page (HTML)"/>
+  <adtcore:packageRef adtcore:uri="/sap/bc/adt/packages/mga" adtcore:type="DEVC/K" adtcore:name="MGA" adtcore:description="Application development R/3 material master from 3.0"/>
+  <doma:content>
+    <doma:typeInformation>
+      <doma:datatype>CHAR</doma:datatype>
+      <doma:length>000004</doma:length>
+      <doma:decimals>000000</doma:decimals>
+    </doma:typeInformation>
+    <doma:outputInformation>
+      <doma:length>000004</doma:length>
+      <doma:style>00</doma:style>
+      <doma:conversionExit/>
+      <doma:signExists>false</doma:signExists>
+      <doma:lowercase>false</doma:lowercase>
+      <doma:ampmFormat>false</doma:ampmFormat>
+    </doma:outputInformation>
+    <doma:valueInformation>
+      <doma:valueTableRef adtcore:uri="/sap/bc/adt/ddic/tables/tmbg" adtcore:type="TABL/DT" adtcore:name="TMBG"/>
+      <doma:appendExists>false</doma:appendExists>
+      <doma:fixValues>
+        <doma:fixValue>
+          <doma:position>0006</doma:position>
+          <doma:low>H</doma:low>
+          <doma:high/>
+          <doma:text>History</doma:text>
+        </doma:fixValue>
+        <doma:fixValue>
+          <doma:position>0007</doma:position>
+          <doma:low>X</doma:low>
+          <doma:high/>
+          <doma:text>Xml</doma:text>
+        </doma:fixValue>
+      </doma:fixValues>
+    </doma:valueInformation>
+  </doma:content>
+</doma:domain>'''

--- a/test/unit/test_sap_adt_connection.py
+++ b/test/unit/test_sap_adt_connection.py
@@ -14,6 +14,73 @@ from mock import Request, Response, Connection
 from fixtures_adt import ERROR_XML_PACKAGE_ALREADY_EXISTS, DISCOVERY_ADT_XML
 
 
+class TestADTErrorHandler(unittest.TestCase):
+
+    def test_without_content_type(self):
+        client = Mock()
+        req = Mock()
+
+        res = Mock()
+        res.status_code = 500
+        res.headers = {}
+        res.text = 'arbitrary crash'
+
+        # shall not raise
+        sap.adt.core._adt_http_error_handler(client, req, res)
+        self.assertTrue(True)
+
+    def test_without_content_type_xml(self):
+        client = Mock()
+        req = Mock()
+
+        res = Mock()
+        res.status_code = 500
+        res.headers = {'content-type': 'application/json'}
+        res.text = 'arbitrary crash'
+
+        # shall not raise
+        sap.adt.core._adt_http_error_handler(client, req, res)
+        self.assertTrue(True)
+
+    @patch('sap.adt.core.new_adt_error_from_xml')
+    def test_with_content_type(self, fake_new_adt_error_from_xml):
+        client = Mock()
+        req = Mock()
+
+        res = Mock()
+        res.status_code = 500
+        res.headers = {'content-type': 'application/xml'}
+        res.text = 'standard ADT error'
+
+        expected_error = sap.adt.errors.ADTError('com.sap.adt', 'ADHOC', 'Parsed ADT error')
+        fake_new_adt_error_from_xml.return_value = expected_error
+
+        with self.assertRaises(sap.adt.errors.ADTError) as cm:
+            sap.adt.core._adt_http_error_handler(client, req, res)
+
+        self.assertTrue(fake_new_adt_error_from_xml.called)
+        self.assertIs(cm.exception, expected_error)
+
+    @patch('sap.adt.core.new_adt_error_from_xml')
+    def test_with_content_type_and_charset(self, fake_new_adt_error_from_xml):
+        client = Mock()
+        req = Mock()
+
+        res = Mock()
+        res.status_code = 500
+        res.headers = {'content-type': 'application/xml; charset=utf-8'}
+        res.text = 'standard ADT error'
+
+        expected_error = sap.adt.errors.ADTError('com.sap.adt', 'ADHOC', 'Parsed ADT error')
+        fake_new_adt_error_from_xml.return_value = expected_error
+
+        with self.assertRaises(sap.adt.errors.ADTError) as cm:
+            sap.adt.core._adt_http_error_handler(client, req, res)
+
+        self.assertTrue(fake_new_adt_error_from_xml.called)
+        self.assertIs(cm.exception, expected_error)
+
+
 class TestADTConnection(unittest.TestCase):
     """Connection(host, client, user, password, port=None, ssl=True)"""
 

--- a/test/unit/test_sap_adt_domain.py
+++ b/test/unit/test_sap_adt_domain.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import unittest
+import sap.adt
+import sap.adt.domain
+
+from mock import Connection, Response
+from fixtures_adt_domain import DOMAIN_NAME, DOMAIN_ADT_GET_RESPONSE_XML
+
+
+class TestADTDomain(unittest.TestCase):
+
+    def test_domain_fetch(self):
+        connection = Connection([Response(text=DOMAIN_ADT_GET_RESPONSE_XML, status_code=200, headers={})])
+
+        domain = sap.adt.Domain(connection, DOMAIN_NAME)
+        domain.fetch()
+
+        self.assertEqual(domain.name, DOMAIN_NAME)
+        self.assertEqual(domain.active, 'active')
+        self.assertEqual(domain.description, 'Authorization group in the material master')
+        self.assertEqual(domain._metadata.package_reference.name, 'MGA')
+
+        # Test type information
+        self.assertEqual(domain.content.type_information.datatype, 'CHAR')
+        self.assertEqual(domain.content.type_information.length, '000004')
+        self.assertEqual(domain.content.type_information.decimals, '000000')
+
+        # Test output information
+        self.assertEqual(domain.content.output_information.length, '000004')
+        self.assertEqual(domain.content.output_information.style, '00')
+        self.assertEqual(domain.content.output_information.sign_exists, 'false')
+        self.assertEqual(domain.content.output_information.lowercase, 'false')
+        self.assertEqual(domain.content.output_information.ampm_format, 'false')
+
+        # Test value information
+        self.assertEqual(domain.content.value_information.value_table_ref.name, 'TMBG')
+        self.assertEqual(domain.content.value_information.value_table_ref.uri, '/sap/bc/adt/ddic/tables/tmbg')
+        self.assertEqual(domain.content.value_information.value_table_ref.typ, 'TABL/DT')
+        self.assertEqual(domain.content.value_information.append_exists, 'false')
+
+        # Test fix values
+        self.assertEqual(len(domain.content.value_information.fix_values), 2)
+        self.assertEqual(domain.content.value_information.fix_values[0].position, '0006')
+        self.assertEqual(domain.content.value_information.fix_values[0].low, 'H')
+        self.assertEqual(domain.content.value_information.fix_values[0].text, 'History')
+        self.assertEqual(domain.content.value_information.fix_values[1].position, '0007')
+        self.assertEqual(domain.content.value_information.fix_values[1].low, 'X')
+        self.assertEqual(domain.content.value_information.fix_values[1].text, 'Xml')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_sap_cli_dataelement.py
+++ b/test/unit/test_sap_cli_dataelement.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import json
 import unittest
 from unittest.mock import call, patch, Mock
 from sap.adt.errors import ExceptionResourceAlreadyExists
@@ -25,7 +26,8 @@ from fixtures_adt_dataelement import (
     DATA_ELEMENT_DEFINITION_ADT_XML,
     DEFINE_DATA_ELEMENT_W_DOMAIN_BODY,
     DEFINE_DATA_ELEMENT_W_PREDEFINED_ABAP_TYPE_BODY,
-    ERROR_XML_DATA_ELEMENT_ALREADY_EXISTS
+    ERROR_XML_DATA_ELEMENT_ALREADY_EXISTS,
+    DOMAIN_ABC_ADT_GET_RESPONSE_XML
 )
 from fixtures_adt_wb import RESPONSE_ACTIVATION_OK
 
@@ -507,3 +509,202 @@ class TestDataElementDefine(unittest.TestCase):
         self.assertEqual(
             'BUG: please report a forgotten case DataElementValidationIssues(9999)',
             str(caught.exception))
+
+
+class TestDataElementRead(unittest.TestCase):
+
+    def data_element_read_cmd(self, *args, **kwargs):
+        # Lazy initialization to avoid module-level CommandGroup instantiation
+        parser = generate_parse_args(sap.cli.dataelement.CommandGroup())
+        return parser('read', *args, **kwargs)
+
+    def test_read_human_format(self):
+        """Test reading data element in HUMAN format"""
+        connection = Connection([
+            Response(text=DATA_ELEMENT_DEFINITION_ADT_XML, status_code=200, headers={})
+        ])
+
+        from mock import BufferConsole
+        console = BufferConsole()
+        the_cmd = self.data_element_read_cmd(DATA_ELEMENT_NAME, '--format=HUMAN')
+        the_cmd.console_factory = lambda: console
+        the_cmd.execute(connection, the_cmd)
+
+        output = console.capout
+
+        # Verify the human-readable output contains expected information
+        self.assertIn('Data Element: TEST_DATA_ELEMENT', output)
+        self.assertIn('Description: Test data element', output)
+        self.assertIn('Package: PACKAGE', output)
+        # Check for new nested structure
+        self.assertIn('Definition:', output)
+        self.assertIn('Type', output)
+        self.assertIn('Kind: predefinedAbapType', output)
+        self.assertIn('Name: STRING', output)
+
+    def test_read_uppercase_name(self):
+        """Test that lowercase input is converted to uppercase"""
+        connection = Connection([
+            Response(text=DATA_ELEMENT_DEFINITION_ADT_XML, status_code=200, headers={})
+        ])
+
+        from mock import BufferConsole
+        console = BufferConsole()
+        the_cmd = self.data_element_read_cmd('test_data_element')  # lowercase
+        the_cmd.console_factory = lambda: console
+        the_cmd.execute(connection, the_cmd)
+
+        # Should work and show uppercase name in output
+        self.assertIn('Data Element: TEST_DATA_ELEMENT', console.capout)
+
+    def test_read_abap_format_not_implemented(self):
+        """Test that ABAP format works"""
+        connection = Connection([
+            Response(text=DATA_ELEMENT_DEFINITION_ADT_XML, status_code=200, headers={})
+        ])
+
+        from mock import BufferConsole
+        console = BufferConsole()
+        the_cmd = self.data_element_read_cmd(DATA_ELEMENT_NAME, '--format=ABAP')
+        the_cmd.console_factory = lambda: console
+
+        the_cmd.execute(connection, the_cmd)
+
+        # Parse the JSON output
+        output = json.loads(console.capout)
+        self.assertEqual(output['formatVersion'], '1')
+        self.assertEqual(output['header']['description'], 'Test data element')
+        self.assertEqual(output['definition']['typeKind'], 'predefinedAbapType')
+        self.assertEqual(output['definition']['dataType'], 'STRING')
+
+
+class TestDataElementReadWithExpand(unittest.TestCase):
+
+    def data_element_read_cmd(self, *args, **kwargs):
+        # Lazy initialization to avoid module-level CommandGroup instantiation
+        parser = generate_parse_args(sap.cli.dataelement.CommandGroup())
+        return parser('read', *args, **kwargs)
+
+    def test_read_human_domain_based_shows_domain_details(self):
+        """Test domain-based data element always shows domain details in HUMAN format"""
+
+        connection = Connection([
+            Response(text=DEFINE_DATA_ELEMENT_W_DOMAIN_BODY, status_code=200, headers={}),  # dataelement fetch
+            Response(text=DOMAIN_ABC_ADT_GET_RESPONSE_XML, status_code=200, headers={})  # domain fetch
+        ])
+
+        from mock import BufferConsole
+        console = BufferConsole()
+        the_cmd = self.data_element_read_cmd(DATA_ELEMENT_NAME)
+        the_cmd.console_factory = lambda: console
+        the_cmd.execute(connection, the_cmd)
+
+        output = console.capout
+
+        # Verify dataelement info is present
+        self.assertIn('Data Element: TEST_DATA_ELEMENT', output)
+        self.assertIn('Definition:', output)
+        self.assertIn('Type', output)
+        self.assertIn('Kind: domain', output)
+        self.assertIn('Name: ABC', output)
+
+        # Verify domain details are shown inline under Type
+        self.assertIn('Description:', output)
+        self.assertIn('Type Information:', output)
+        self.assertIn('Datatype:', output)
+
+    def test_read_human_domain_fetch_failure(self):
+        """Test reading domain-based data element when domain fetch fails"""
+        connection = Connection([
+            Response(text=DEFINE_DATA_ELEMENT_W_DOMAIN_BODY, status_code=200, headers={}),  # dataelement fetch
+            Response(text='Domain not found', status_code=404, headers={})  # domain fetch fails
+        ])
+
+        from mock import BufferConsole
+        console = BufferConsole()
+        the_cmd = self.data_element_read_cmd(DATA_ELEMENT_NAME)
+        the_cmd.console_factory = lambda: console
+
+        # Should not raise exception, but print warning
+        the_cmd.execute(connection, the_cmd)
+
+        output = console.capout
+        # Verify dataelement info is still present
+        self.assertIn('Data Element: TEST_DATA_ELEMENT', output)
+        self.assertIn('Kind: domain', output)
+
+        # Check stderr for warning
+        self.assertIn('Warning:', console.caperr)
+
+    def test_read_human_predefined_type_no_domain_details(self):
+        """Test predefined ABAP type data element doesn't show domain details"""
+        connection = Connection([
+            Response(text=DATA_ELEMENT_DEFINITION_ADT_XML, status_code=200, headers={})
+        ])
+
+        from mock import BufferConsole
+        console = BufferConsole()
+        the_cmd = self.data_element_read_cmd(DATA_ELEMENT_NAME)
+        the_cmd.console_factory = lambda: console
+        the_cmd.execute(connection, the_cmd)
+
+        output = console.capout
+
+        # Verify dataelement info is present
+        self.assertIn('Data Element: TEST_DATA_ELEMENT', output)
+        self.assertIn('Kind: predefinedAbapType', output)
+
+        # Domain description/details should NOT be present
+        self.assertNotIn('Domain:', output)
+        self.assertNotIn('Test Domain ABC', output)
+
+    def test_read_abap_format_no_domain_details(self):
+        """Test ABAP format does not include domain details"""
+
+        connection = Connection([
+            Response(text=DEFINE_DATA_ELEMENT_W_DOMAIN_BODY, status_code=200, headers={}),  # dataelement fetch
+            # No domain fetch - ABAP format should not trigger domain fetch
+        ])
+
+        from mock import BufferConsole
+        console = BufferConsole()
+        the_cmd = self.data_element_read_cmd(DATA_ELEMENT_NAME, '--format=ABAP')
+        the_cmd.console_factory = lambda: console
+        the_cmd.execute(connection, the_cmd)
+
+        # Parse JSON output
+        output = json.loads(console.capout)
+
+        # Verify basic structure
+        self.assertEqual(output['formatVersion'], '1')
+        self.assertEqual(output['definition']['typeKind'], 'domain')
+        self.assertEqual(output['definition']['domainName'], 'ABC')
+
+        # Domain details should NOT be embedded
+        self.assertNotIn('domainDetails', output)
+
+    def test_read_abap_format_predefined_type(self):
+        """Test ABAP format for predefined ABAP type"""
+        connection = Connection([
+            Response(text=DATA_ELEMENT_DEFINITION_ADT_XML, status_code=200, headers={})
+        ])
+
+        from mock import BufferConsole
+        console = BufferConsole()
+        the_cmd = self.data_element_read_cmd(DATA_ELEMENT_NAME, '--format=ABAP')
+        the_cmd.console_factory = lambda: console
+        the_cmd.execute(connection, the_cmd)
+
+        # Parse JSON output
+        output = json.loads(console.capout)
+
+        # Verify basic structure
+        self.assertEqual(output['formatVersion'], '1')
+        self.assertEqual(output['definition']['typeKind'], 'predefinedAbapType')
+        self.assertIn('dataType', output['definition'])
+        self.assertIn('length', output['definition'])
+        self.assertIn('decimals', output['definition'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_sap_cli_domain.py
+++ b/test/unit/test_sap_cli_domain.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+import unittest
+import json
+
+import sap.cli.domain
+from sap.errors import SAPCliError
+
+from mock import (
+    BufferConsole,
+    Connection,
+    Response,
+)
+
+from infra import generate_parse_args
+from fixtures_adt_domain import (
+    DOMAIN_NAME,
+    DOMAIN_ADT_GET_RESPONSE_XML,
+)
+
+
+class TestDomainRead(unittest.TestCase):
+
+    def domain_read_cmd(self, *args, **kwargs):
+        # Lazy initialization to avoid module-level CommandGroup instantiation
+        parser = generate_parse_args(sap.cli.domain.CommandGroup())
+        return parser('read', *args, **kwargs)
+
+    def test_read_abap_format(self):
+        """Test reading domain in ABAP (JSON) format"""
+        connection = Connection([
+            Response(text=DOMAIN_ADT_GET_RESPONSE_XML, status_code=200, headers={})
+        ])
+
+        console = BufferConsole()
+        the_cmd = self.domain_read_cmd(DOMAIN_NAME)
+        the_cmd.console_factory = lambda: console
+        the_cmd.execute(connection, the_cmd)
+
+        # Parse the output as JSON
+        output = json.loads(console.capout)
+
+        # Verify the structure matches the expected ABAP format
+        self.assertEqual(output['formatVersion'], '1')
+        self.assertEqual(output['header']['description'], 'Authorization group in the material master')
+        self.assertEqual(output['header']['originalLanguage'], 'en')
+        self.assertEqual(output['format']['dataType'], 'CHAR')
+        self.assertEqual(output['format']['length'], 4)
+        self.assertEqual(output['outputCharacteristics']['length'], 4)
+
+        # Verify fixed values
+        self.assertEqual(len(output['fixedValues']), 2)
+        self.assertEqual(output['fixedValues'][0]['fixedValue'], 'H')
+        self.assertEqual(output['fixedValues'][0]['description'], 'History')
+        self.assertEqual(output['fixedValues'][1]['fixedValue'], 'X')
+        self.assertEqual(output['fixedValues'][1]['description'], 'Xml')
+
+    def test_read_human_format(self):
+        """Test reading domain in HUMAN format"""
+        connection = Connection([
+            Response(text=DOMAIN_ADT_GET_RESPONSE_XML, status_code=200, headers={})
+        ])
+
+        console = BufferConsole()
+        the_cmd = self.domain_read_cmd(DOMAIN_NAME, '--format=HUMAN')
+        the_cmd.console_factory = lambda: console
+        the_cmd.execute(connection, the_cmd)
+
+        output = console.capout
+
+        # Verify the human-readable output contains expected information
+        self.assertIn('Domain: BEGRM', output)
+        self.assertIn('Description: Authorization group in the material master', output)
+        self.assertIn('Package: MGA', output)
+        self.assertIn('Datatype: CHAR', output)
+        self.assertIn('Length: 4', output)
+        self.assertIn('Table Reference: TMBG', output)
+        self.assertIn('- H: History', output)
+        self.assertIn('- X: Xml', output)
+
+    def test_read_uppercase_name(self):
+        """Test that lowercase input is converted to uppercase"""
+        connection = Connection([
+            Response(text=DOMAIN_ADT_GET_RESPONSE_XML, status_code=200, headers={})
+        ])
+
+        console = BufferConsole()
+        the_cmd = self.domain_read_cmd('begrm')  # lowercase
+        the_cmd.console_factory = lambda: console
+        the_cmd.execute(connection, the_cmd)
+
+        # Parse the output as JSON (default format is ABAP)
+        output = json.loads(console.capout)
+        # The connection should have been called with uppercase name
+        self.assertEqual(connection.execs[0].adt_uri, '/sap/bc/adt/ddic/domains/begrm')
+
+
+class TestDomainUnsupportedOperations(unittest.TestCase):
+    """Test that unsupported operations raise appropriate errors"""
+
+    def test_create_not_supported(self):
+        """Test that create operation raises error"""
+        connection = Connection()
+        cmd_group = sap.cli.domain.CommandGroup()
+
+        with self.assertRaises(SAPCliError) as cm:
+            cmd_group.create_object(connection, None)
+
+        self.assertIn('Create Domain is not supported', str(cm.exception))
+
+    def test_delete_not_supported(self):
+        """Test that delete operation raises error"""
+        connection = Connection()
+        cmd_group = sap.cli.domain.CommandGroup()
+
+        with self.assertRaises(SAPCliError) as cm:
+            cmd_group.delete_object(connection, None)
+
+        self.assertIn('Delete Domain is not supported', str(cm.exception))
+
+    def test_write_not_supported(self):
+        """Test that write operation raises error"""
+        connection = Connection()
+        cmd_group = sap.cli.domain.CommandGroup()
+
+        with self.assertRaises(SAPCliError) as cm:
+            cmd_group.write_object_text(connection, None)
+
+        self.assertIn('Write Domain is not supported', str(cm.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_sap_cli_domain_formatter.py
+++ b/test/unit/test_sap_cli_domain_formatter.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import sap.cli.domain_formatter
+from mock import BufferConsole, Connection, Response
+from fixtures_adt_domain import DOMAIN_NAME, DOMAIN_ADT_GET_RESPONSE_XML
+import sap.adt
+
+
+class TestDomainFormatterHuman(unittest.TestCase):
+
+    def test_format_domain_human_basic(self):
+        """Test basic domain formatting without indent"""
+        connection = Connection([Response(text=DOMAIN_ADT_GET_RESPONSE_XML, status_code=200, headers={})])
+        domain = sap.adt.Domain(connection, DOMAIN_NAME)
+        domain.fetch()
+
+        console = BufferConsole()
+        sap.cli.domain_formatter.format_domain_human(console, domain, indent='')
+
+        output = console.capout
+        self.assertIn('Type Information:', output)
+        self.assertIn('Datatype: CHAR', output)
+        self.assertIn('Length: 4', output)
+        self.assertIn('Output Information:', output)
+        self.assertIn('Value Information:', output)
+
+    def test_format_domain_human_with_indent(self):
+        """Test domain formatting with indentation"""
+        connection = Connection([Response(text=DOMAIN_ADT_GET_RESPONSE_XML, status_code=200, headers={})])
+        domain = sap.adt.Domain(connection, DOMAIN_NAME)
+        domain.fetch()
+
+        console = BufferConsole()
+        sap.cli.domain_formatter.format_domain_human(console, domain, indent='    ')
+
+        output = console.capout
+        # Check that indentation is applied
+        self.assertIn('    Type Information:', output)
+        self.assertIn('    Output Information:', output)
+        self.assertIn('    Value Information:', output)
+
+    def test_format_domain_human_with_fixed_values(self):
+        """Test domain formatting includes fixed values"""
+        connection = Connection([Response(text=DOMAIN_ADT_GET_RESPONSE_XML, status_code=200, headers={})])
+        domain = sap.adt.Domain(connection, DOMAIN_NAME)
+        domain.fetch()
+
+        console = BufferConsole()
+        sap.cli.domain_formatter.format_domain_human(console, domain, indent='')
+
+        output = console.capout
+        self.assertIn('Fix Values:', output)
+        self.assertIn('- H: History', output)
+        self.assertIn('- X: Xml', output)
+
+    def test_format_domain_human_with_table_ref(self):
+        """Test domain formatting includes table reference"""
+        connection = Connection([Response(text=DOMAIN_ADT_GET_RESPONSE_XML, status_code=200, headers={})])
+        domain = sap.adt.Domain(connection, DOMAIN_NAME)
+        domain.fetch()
+
+        console = BufferConsole()
+        sap.cli.domain_formatter.format_domain_human(console, domain, indent='')
+
+        output = console.capout
+        self.assertIn('Table Reference: TMBG', output)
+
+
+class TestDomainFormatterAbap(unittest.TestCase):
+
+    def test_format_domain_abap(self):
+        """Test ABAP format dict structure"""
+        connection = Connection([Response(text=DOMAIN_ADT_GET_RESPONSE_XML, status_code=200, headers={})])
+        domain = sap.adt.Domain(connection, DOMAIN_NAME)
+        domain.fetch()
+
+        output = sap.cli.domain_formatter.format_domain_abap(domain)
+
+        self.assertEqual(output['formatVersion'], '1')
+        self.assertEqual(output['header']['description'], 'Authorization group in the material master')
+        self.assertEqual(output['header']['originalLanguage'], 'en')
+        self.assertEqual(output['format']['dataType'], 'CHAR')
+        self.assertEqual(output['format']['length'], 4)
+        self.assertEqual(output['outputCharacteristics']['length'], 4)
+
+    def test_format_domain_abap_with_fixed_values(self):
+        """Test ABAP format includes fixed values"""
+        connection = Connection([Response(text=DOMAIN_ADT_GET_RESPONSE_XML, status_code=200, headers={})])
+        domain = sap.adt.Domain(connection, DOMAIN_NAME)
+        domain.fetch()
+
+        output = sap.cli.domain_formatter.format_domain_abap(domain)
+
+        self.assertIn('fixedValues', output)
+        self.assertEqual(len(output['fixedValues']), 2)
+        self.assertEqual(output['fixedValues'][0]['fixedValue'], 'H')
+        self.assertEqual(output['fixedValues'][0]['description'], 'History')
+        self.assertEqual(output['fixedValues'][1]['fixedValue'], 'X')
+        self.assertEqual(output['fixedValues'][1]['description'], 'Xml')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Again, modify operations are disabled because testing is trivial and we do not have enough data.

I am happy to enable the operations, if somebody spends time testing it.