### PR TITLE
Human ATC location

### DIFF
--- a/sap/cli/atc.py
+++ b/sap/cli/atc.py
@@ -51,6 +51,18 @@ class CommandGroup(sap.cli.core.CommandGroup):
         self.profile_grp.install_parser(profile_parser)
 
 
+def _format_human_location(location):
+    """Format finding location for human output"""
+
+    line, column = get_line_and_column(location)
+
+    if line == '0':
+        return 'entire object'
+    if column == '0':
+        return f'line={line}'
+    return f'line={line}, column={column}'
+
+
 def print_worklists_to_stream(all_results, stream, error_level=99, priority_filter=5):
     """Print results to stream"""
 
@@ -66,7 +78,11 @@ def print_worklists_to_stream(all_results, stream, error_level=99, priority_filt
                 if int(finding.priority) <= error_level:
                     ret += 1
 
-                stream.write(f'*{finiding_pad}{finding.priority} :: {finding.check_title} :: {finding.message_title}\n')
+                location_suffix = _format_human_location(finding.location)
+                prio = finding.priority
+                title = finding.check_title
+                msg = finding.message_title
+                stream.write(f'*{finiding_pad}{prio} :: {title} :: {msg} :: {location_suffix}\n')
 
     return 0 if ret < 1 else 1
 

--- a/test/unit/test_sap_cli_atc.py
+++ b/test/unit/test_sap_cli_atc.py
@@ -346,10 +346,10 @@ class TestPrintWorklistToStream(TestPrintWorklistMixin, unittest.TestCase):
         ret = sap.cli.atc.print_worklists_to_stream([self.worklist], output)
         self.assertEqual(output.getvalue(),
 '''FAKE/TEST/MADE_UP_OBJECT
-* 1 :: UNIT_TEST :: Unit tests for ATC module of sapcli
-* 2 :: PRIO_2 :: Prio 2
-* 3 :: PRIO_3 :: Prio 3
-* 4 :: PRIO_4 :: Prio 4
+* 1 :: UNIT_TEST :: Unit tests for ATC module of sapcli :: line=24
+* 2 :: PRIO_2 :: Prio 2 :: line=24, column=32
+* 3 :: PRIO_3 :: Prio 3 :: entire object
+* 4 :: PRIO_4 :: Prio 4 :: entire object
 ''')
         self.assertEqual(1, ret)
 
@@ -358,10 +358,10 @@ class TestPrintWorklistToStream(TestPrintWorklistMixin, unittest.TestCase):
         ret = sap.cli.atc.print_worklists_to_stream([self.worklist], output, error_level=2, priority_filter=5)
         self.assertEqual(output.getvalue(),
 '''FAKE/TEST/MADE_UP_OBJECT
-* 1 :: UNIT_TEST :: Unit tests for ATC module of sapcli
-* 2 :: PRIO_2 :: Prio 2
-* 3 :: PRIO_3 :: Prio 3
-* 4 :: PRIO_4 :: Prio 4
+* 1 :: UNIT_TEST :: Unit tests for ATC module of sapcli :: line=24
+* 2 :: PRIO_2 :: Prio 2 :: line=24, column=32
+* 3 :: PRIO_3 :: Prio 3 :: entire object
+* 4 :: PRIO_4 :: Prio 4 :: entire object
 ''')
         self.assertEqual(1, ret)
 
@@ -370,10 +370,10 @@ class TestPrintWorklistToStream(TestPrintWorklistMixin, unittest.TestCase):
         ret = sap.cli.atc.print_worklists_to_stream([self.worklist], output, error_level=0)
         self.assertEqual(output.getvalue(),
 '''FAKE/TEST/MADE_UP_OBJECT
-* 1 :: UNIT_TEST :: Unit tests for ATC module of sapcli
-* 2 :: PRIO_2 :: Prio 2
-* 3 :: PRIO_3 :: Prio 3
-* 4 :: PRIO_4 :: Prio 4
+* 1 :: UNIT_TEST :: Unit tests for ATC module of sapcli :: line=24
+* 2 :: PRIO_2 :: Prio 2 :: line=24, column=32
+* 3 :: PRIO_3 :: Prio 3 :: entire object
+* 4 :: PRIO_4 :: Prio 4 :: entire object
 ''')
         self.assertEqual(0, ret)
 
@@ -382,7 +382,7 @@ class TestPrintWorklistToStream(TestPrintWorklistMixin, unittest.TestCase):
         ret = sap.cli.atc.print_worklists_to_stream([self.worklist], output, priority_filter=1)
         self.assertEqual(output.getvalue(),
 '''FAKE/TEST/MADE_UP_OBJECT
-* 1 :: UNIT_TEST :: Unit tests for ATC module of sapcli
+* 1 :: UNIT_TEST :: Unit tests for ATC module of sapcli :: line=24
 ''')
         self.assertEqual(1, ret)
 


### PR DESCRIPTION
Humans and even coding agents need to see where the ATC finding is located. Currently the human format prints only information about the ATC finding, but not where it is located in the code. This makes it difficult for humans to understand the context of the finding and to locate it in the code.

The ATC finding object already contains the location information because the output format checkstyle displays it. We can reuse this information in the human output format.

The location information is stored in the XML tag atcfinding:finding as attribute atcfinding:location.

The attribute atcfinding:location holds and URI which contains the affected object identifier and may contains suffix #start=line,column which indicates the line and column of the finding in the code. If the suffix is not present, it means that the finding is located in the entire object and not specific to a line or column.

Current format:
    * 1 :: UNIT_TEST :: Unit tests for ATC module of sapcli
    * 2 :: PRIO_2 :: Prio 2
    * 3 :: PRIO_3 :: Prio 3
    * 4 :: PRIO_4 :: Prio 4

New format:
    * 1 :: UNIT_TEST :: Unit tests for ATC module of sapcli :: line=24
    * 2 :: PRIO_2 :: Prio 2 :: line=24, column=32
    * 3 :: PRIO_3 :: Prio 3 :: entire object
    * 4 :: PRIO_4 :: Prio 4 :: entire object