### PR TITLE
http: introduce auth-plugin protocol module

### DIFF
--- a/sap/http/auth_plugin.py
+++ b/sap/http/auth_plugin.py
@@ -1,0 +1,158 @@
+"""Plugin protocol for external authentication helpers.
+
+sapcli runs an external command (the auth plugin) as a subprocess, writes a
+JSON authentication request to its stdin, and parses the JSON response from
+its stdout. This module defines the request/response shape and the
+``run_plugin`` driver. Interpretation of the response payload (cookies,
+Authorization header, client certificate) is the responsibility of the
+caller - see ``sap.http.external_session_initializer``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Optional
+
+from sap.errors import SAPCliError
+
+
+class AuthPluginError(SAPCliError):
+    """Raised when the auth plugin cannot be invoked or returns invalid output."""
+
+
+@dataclass(frozen=True)
+class ConnectionInfo:
+    """Connection details forwarded to the plugin in the request payload."""
+
+    proto: str
+    ashost: str
+    port: str
+    client: str
+    type: str
+    path: str
+    # Optional because HTTP-only plugins have no use for it; required by RFC
+    # plugins (and by ABAP RFC SDK callers in general) since sysnr selects
+    # the application-server instance (gateway port = 33<sysnr>).
+    sysnr: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        """Return the JSON-serializable form."""
+
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AuthPluginRequest:
+    """Request sent to the plugin on stdin."""
+
+    connection: ConnectionInfo
+    parameters: dict
+
+    def to_dict(self) -> dict:
+        """Return the JSON-serializable form."""
+
+        return {
+            'connection': self.connection.to_dict(),
+            'parameters': dict(self.parameters),
+        }
+
+    def to_json(self) -> str:
+        """Return the JSON string ready for stdin."""
+
+        return json.dumps(self.to_dict())
+
+
+@dataclass(frozen=True)
+class AuthPluginResponse:
+    """Response received from the plugin on stdout."""
+
+    message: str
+    content: dict
+    expiration: Optional[datetime] = None
+
+    @classmethod
+    def from_dict(cls, data) -> 'AuthPluginResponse':
+        """Build a response from a parsed JSON object, validating required fields."""
+
+        if not isinstance(data, dict):
+            raise ValueError(
+                f'response is not a JSON object, got {type(data).__name__}'
+            )
+
+        if 'message' not in data:
+            raise ValueError("response missing required field 'message'")
+
+        if 'content' not in data:
+            raise ValueError("response missing required field 'content'")
+
+        return cls(
+            message=data['message'],
+            content=data['content'],
+            expiration=_parse_expiration(data.get('expiration')),
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> 'AuthPluginResponse':
+        """Build a response from a JSON string."""
+
+        return cls.from_dict(json.loads(raw))
+
+
+def _parse_expiration(value) -> Optional[datetime]:
+    if not value:
+        return None
+
+    if not isinstance(value, str):
+        raise ValueError(
+            f'expiration must be an ISO 8601 string, got {type(value).__name__}'
+        )
+
+    # datetime.fromisoformat in 3.10 does not understand the trailing Z;
+    # rewriting it to +00:00 keeps the parser portable across versions.
+    normalized = value[:-1] + '+00:00' if value.endswith('Z') else value
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError as ex:
+        raise ValueError(f'invalid expiration {value!r}: {ex}') from ex
+
+
+def run_plugin(command: str, parameters, connection: ConnectionInfo) -> AuthPluginResponse:
+    """Run the external auth plugin and return its parsed response.
+
+    Raises ``AuthPluginError`` if the plugin cannot be started, exits non-zero,
+    or returns output that is not a valid response.
+    """
+
+    request = AuthPluginRequest(connection=connection, parameters=parameters or {})
+
+    try:
+        completed = subprocess.run(
+            [command],
+            input=request.to_json(),
+            capture_output=True,
+            check=False,
+            encoding='utf-8',
+        )
+    except OSError as ex:
+        raise AuthPluginError(
+            f"Failed to start auth plugin '{command}': {ex}"
+        ) from ex
+
+    if completed.returncode != 0:
+        raise AuthPluginError(
+            f"Auth plugin '{command}' exited with code {completed.returncode}\n"
+            f"stdout: {completed.stdout}\n"
+            f"stderr: {completed.stderr}"
+        )
+
+    try:
+        return AuthPluginResponse.from_json(completed.stdout)
+    except (ValueError, TypeError) as ex:
+        raise AuthPluginError(
+            f"Auth plugin '{command}' returned invalid response: {ex}\n"
+            f"stdout: {completed.stdout}\n"
+            f"stderr: {completed.stderr}"
+        ) from ex

--- a/test/unit/test_sap_http_auth_plugin.py
+++ b/test/unit/test_sap_http_auth_plugin.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from sap.errors import SAPCliError
+from sap.http.auth_plugin import (
+    AuthPluginError,
+    AuthPluginRequest,
+    AuthPluginResponse,
+    ConnectionInfo,
+    run_plugin,
+)
+
+
+def _connection():
+    return ConnectionInfo(
+        proto='https',
+        ashost='abap.example.org',
+        port='44300',
+        client='100',
+        type='adt',
+        path='/sap/bc/adt/core/systeminformation',
+    )
+
+
+def _completed_process(stdout='', stderr='', returncode=0):
+    return subprocess.CompletedProcess(
+        args=['plugin'],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+class TestConnectionInfo(unittest.TestCase):
+
+    def test_to_dict_emits_all_fields(self):
+        ci = _connection()
+
+        self.assertEqual(ci.to_dict(), {
+            'proto': 'https',
+            'ashost': 'abap.example.org',
+            'port': '44300',
+            'client': '100',
+            'type': 'adt',
+            'path': '/sap/bc/adt/core/systeminformation',
+            'sysnr': None,
+        })
+
+    def test_sysnr_defaults_to_none(self):
+        # sysnr is only meaningful for RFC-based plugins; HTTP plugins can
+        # ignore it. Defaulting to None keeps construction noise-free for
+        # the common HTTP case.
+        ci = _connection()
+
+        self.assertIsNone(ci.sysnr)
+
+    def test_to_dict_includes_sysnr_when_set(self):
+        ci = ConnectionInfo(
+            proto='https',
+            ashost='abap.example.org',
+            port='44300',
+            client='100',
+            type='adt',
+            path='/sap/bc/adt/core/systeminformation',
+            sysnr='00',
+        )
+
+        self.assertEqual(ci.to_dict()['sysnr'], '00')
+
+
+class TestAuthPluginRequest(unittest.TestCase):
+
+    def test_to_dict_nests_connection_and_parameters(self):
+        request = AuthPluginRequest(
+            connection=ConnectionInfo(
+                proto='https',
+                ashost='abap.example.org',
+                port='44300',
+                client='100',
+                type='adt',
+                path='/sap/bc/adt/core/systeminformation',
+                sysnr='00',
+            ),
+            parameters={'channel': 'msedge'},
+        )
+
+        self.assertEqual(request.to_dict(), {
+            'connection': {
+                'proto': 'https',
+                'ashost': 'abap.example.org',
+                'port': '44300',
+                'client': '100',
+                'type': 'adt',
+                'path': '/sap/bc/adt/core/systeminformation',
+                'sysnr': '00',
+            },
+            'parameters': {'channel': 'msedge'},
+        })
+
+    def test_to_json_round_trips_through_to_dict(self):
+        request = AuthPluginRequest(
+            connection=_connection(),
+            parameters={'channel': 'msedge'},
+        )
+
+        self.assertEqual(json.loads(request.to_json()), request.to_dict())
+
+    def test_to_dict_with_empty_parameters(self):
+        request = AuthPluginRequest(connection=_connection(), parameters={})
+
+        self.assertEqual(request.to_dict()['parameters'], {})
+
+
+class TestAuthPluginResponseFromDict(unittest.TestCase):
+
+    def test_minimal_required_fields(self):
+        response = AuthPluginResponse.from_dict({
+            'message': 'OK',
+            'content': {'type': 'cookie', 'cookies': []},
+        })
+
+        self.assertEqual(response.message, 'OK')
+        self.assertEqual(response.content, {'type': 'cookie', 'cookies': []})
+        self.assertIsNone(response.expiration)
+
+    def test_parses_iso_expiration_with_z_suffix(self):
+        response = AuthPluginResponse.from_dict({
+            'message': 'OK',
+            'content': {'type': 'cookie', 'cookies': []},
+            'expiration': '2024-12-31T23:59:59Z',
+        })
+
+        self.assertEqual(
+            response.expiration,
+            datetime(2024, 12, 31, 23, 59, 59, tzinfo=timezone.utc),
+        )
+
+    def test_parses_iso_expiration_with_offset(self):
+        response = AuthPluginResponse.from_dict({
+            'message': 'OK',
+            'content': {'type': 'cookie', 'cookies': []},
+            'expiration': '2024-12-31T23:59:59+00:00',
+        })
+
+        self.assertEqual(
+            response.expiration,
+            datetime(2024, 12, 31, 23, 59, 59, tzinfo=timezone.utc),
+        )
+
+    def test_null_expiration_yields_none(self):
+        response = AuthPluginResponse.from_dict({
+            'message': 'OK',
+            'content': {'type': 'cookie', 'cookies': []},
+            'expiration': None,
+        })
+
+        self.assertIsNone(response.expiration)
+
+    def test_empty_string_expiration_yields_none(self):
+        response = AuthPluginResponse.from_dict({
+            'message': 'OK',
+            'content': {'type': 'cookie', 'cookies': []},
+            'expiration': '',
+        })
+
+        self.assertIsNone(response.expiration)
+
+    def test_missing_message_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            AuthPluginResponse.from_dict({
+                'content': {'type': 'cookie', 'cookies': []},
+            })
+
+        self.assertIn('message', str(ctx.exception))
+
+    def test_missing_content_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            AuthPluginResponse.from_dict({'message': 'OK'})
+
+        self.assertIn('content', str(ctx.exception))
+
+    def test_non_mapping_input_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            AuthPluginResponse.from_dict(['not', 'a', 'mapping'])
+
+    def test_invalid_expiration_string_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            AuthPluginResponse.from_dict({
+                'message': 'OK',
+                'content': {'type': 'cookie', 'cookies': []},
+                'expiration': 'not-a-date',
+            })
+
+
+class TestAuthPluginResponseFromJSON(unittest.TestCase):
+
+    def test_parses_json_string(self):
+        raw = json.dumps({
+            'message': 'OK',
+            'content': {'type': 'cookie', 'cookies': []},
+        })
+
+        response = AuthPluginResponse.from_json(raw)
+
+        self.assertEqual(response.message, 'OK')
+
+    def test_invalid_json_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            AuthPluginResponse.from_json('this is not json')
+
+
+class TestAuthPluginError(unittest.TestCase):
+
+    def test_inherits_from_sapclierror(self):
+        # CLI entry point relies on SAPCliError to print a friendly message
+        # instead of a stack trace - a non-SAPCliError would regress that.
+        self.assertTrue(issubclass(AuthPluginError, SAPCliError))
+
+
+class TestRunPluginSubprocessInvocation(unittest.TestCase):
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_invokes_command_as_argv(self, mock_run):
+        mock_run.return_value = _completed_process(
+            stdout=json.dumps({
+                'message': 'OK',
+                'content': {'type': 'cookie', 'cookies': []},
+            }),
+        )
+
+        run_plugin('my-plugin', {'channel': 'msedge'}, _connection())
+
+        args, kwargs = mock_run.call_args
+        self.assertEqual(args[0], ['my-plugin'])
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_writes_request_json_to_stdin(self, mock_run):
+        mock_run.return_value = _completed_process(
+            stdout=json.dumps({
+                'message': 'OK',
+                'content': {'type': 'cookie', 'cookies': []},
+            }),
+        )
+
+        run_plugin('my-plugin', {'channel': 'msedge'}, _connection())
+
+        kwargs = mock_run.call_args.kwargs
+        sent = json.loads(kwargs['input'])
+        self.assertEqual(sent, {
+            'connection': _connection().to_dict(),
+            'parameters': {'channel': 'msedge'},
+        })
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_captures_output_as_text_utf8(self, mock_run):
+        mock_run.return_value = _completed_process(
+            stdout=json.dumps({
+                'message': 'OK',
+                'content': {'type': 'cookie', 'cookies': []},
+            }),
+        )
+
+        run_plugin('my-plugin', {}, _connection())
+
+        kwargs = mock_run.call_args.kwargs
+        self.assertTrue(kwargs.get('capture_output'))
+        # Pass encoding so binary output isn't returned and the stdout/stderr
+        # payloads we surface in errors are real strings.
+        self.assertEqual(kwargs.get('encoding'), 'utf-8')
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_does_not_pass_check_kwarg(self, mock_run):
+        # check=True would convert non-zero exit into CalledProcessError before
+        # we get a chance to wrap it; we want to handle the exit code ourselves.
+        mock_run.return_value = _completed_process(
+            stdout=json.dumps({
+                'message': 'OK',
+                'content': {'type': 'cookie', 'cookies': []},
+            }),
+        )
+
+        run_plugin('my-plugin', {}, _connection())
+
+        kwargs = mock_run.call_args.kwargs
+        self.assertFalse(kwargs.get('check', False))
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_does_not_set_timeout(self, mock_run):
+        # Auth plugins may legitimately wait for the user to log in via a
+        # browser; a default timeout would kill them mid-login.
+        mock_run.return_value = _completed_process(
+            stdout=json.dumps({
+                'message': 'OK',
+                'content': {'type': 'cookie', 'cookies': []},
+            }),
+        )
+
+        run_plugin('my-plugin', {}, _connection())
+
+        kwargs = mock_run.call_args.kwargs
+        self.assertIsNone(kwargs.get('timeout'))
+
+
+class TestRunPluginSuccess(unittest.TestCase):
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_returns_parsed_response(self, mock_run):
+        mock_run.return_value = _completed_process(
+            stdout=json.dumps({
+                'message': 'Authentication successful',
+                'content': {
+                    'type': 'cookie',
+                    'cookies': [{'name': 'SAP_SESSION', 'value': 'abc'}],
+                },
+                'expiration': '2025-01-01T00:00:00Z',
+            }),
+        )
+
+        response = run_plugin('my-plugin', {}, _connection())
+
+        self.assertEqual(response.message, 'Authentication successful')
+        self.assertEqual(response.content['type'], 'cookie')
+        self.assertEqual(
+            response.expiration,
+            datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        )
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_accepts_none_parameters(self, mock_run):
+        mock_run.return_value = _completed_process(
+            stdout=json.dumps({
+                'message': 'OK',
+                'content': {'type': 'cookie', 'cookies': []},
+            }),
+        )
+
+        run_plugin('my-plugin', None, _connection())
+
+        sent = json.loads(mock_run.call_args.kwargs['input'])
+        self.assertEqual(sent['parameters'], {})
+
+
+class TestRunPluginFailures(unittest.TestCase):
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_file_not_found_raises_auth_plugin_error(self, mock_run):
+        mock_run.side_effect = FileNotFoundError(2, 'No such file', 'missing-plugin')
+
+        with self.assertRaises(AuthPluginError) as ctx:
+            run_plugin('missing-plugin', {}, _connection())
+
+        self.assertIn('missing-plugin', str(ctx.exception))
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_permission_error_raises_auth_plugin_error(self, mock_run):
+        mock_run.side_effect = PermissionError(13, 'Permission denied', 'plugin')
+
+        with self.assertRaises(AuthPluginError):
+            run_plugin('plugin', {}, _connection())
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_non_zero_exit_raises_with_stderr_in_message(self, mock_run):
+        mock_run.return_value = _completed_process(
+            stdout='partial output',
+            stderr='browser launch failed',
+            returncode=2,
+        )
+
+        with self.assertRaises(AuthPluginError) as ctx:
+            run_plugin('my-plugin', {}, _connection())
+
+        message = str(ctx.exception)
+        self.assertIn('2', message)
+        self.assertIn('browser launch failed', message)
+        self.assertIn('partial output', message)
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_invalid_json_raises_with_stdout_in_message(self, mock_run):
+        mock_run.return_value = _completed_process(stdout='not json at all')
+
+        with self.assertRaises(AuthPluginError) as ctx:
+            run_plugin('my-plugin', {}, _connection())
+
+        self.assertIn('not json at all', str(ctx.exception))
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_missing_required_field_raises(self, mock_run):
+        mock_run.return_value = _completed_process(
+            stdout=json.dumps({'message': 'OK'}),  # missing 'content'
+        )
+
+        with self.assertRaises(AuthPluginError) as ctx:
+            run_plugin('my-plugin', {}, _connection())
+
+        self.assertIn('content', str(ctx.exception))
+
+    @patch('sap.http.auth_plugin.subprocess.run')
+    def test_response_is_array_not_object_raises(self, mock_run):
+        mock_run.return_value = _completed_process(stdout=json.dumps(['oops']))
+
+        with self.assertRaises(AuthPluginError):
+            run_plugin('my-plugin', {}, _connection())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds sap/http/auth_plugin.py: the request/response shape and the run_plugin() driver for kubectl-style external authentication helpers. This is step 1 of the auth-plugin track in features/auth_plugins.md and is independent of CLI wiring and the response cache - those land in follow-up commits.

Why a kubectl-style plugin (vs. building auth methods in-tree): sapcli must support SAML2/SSO and Windows-cert SSO without taking on browser-automation or Win32-API dependencies. Spawning an external command and exchanging JSON over stdin/stdout keeps sapcli's dependency surface minimal and lets each plugin be implemented in whatever language fits the platform (e.g. playwright on Windows).

Design decisions:

- subprocess.run with check=False and no timeout. Browser-based plugins legitimately wait minutes for the user to log in; a default timeout would kill them mid-flow. check=False so we surface our own AuthPluginError with stdout+stderr included instead of a bare CalledProcessError.

- AuthPluginError derives from SAPCliError so the CLI entry point prints a friendly message instead of a stack trace, matching every other user-visible error in the project.

- OSError catches both FileNotFoundError (plugin not on PATH) and PermissionError (plugin not executable); wrapping at OSError keeps the failure path uniform without enumerating each subclass.

- Response validation happens here for the envelope (message, content, optional expiration) but does NOT inspect content's internal shape - that is the session-initializer's job, which dispatches on content.type. Keeps this module's contract narrow.

- Expiration normalises a trailing 'Z' to '+00:00' before datetime.fromisoformat. Python 3.10's parser does not understand the Z suffix; doing it here lets the rest of the codebase stay portable.

- ConnectionInfo carries port as str (matching the wire format in the spec, e.g. "44300") rather than int. The CLI parses port as int, so the caller is responsible for coercion - we do not silently mutate user input.

- ConnectionInfo.sysnr is Optional[str] (default None). HTTP-only plugins have no use for the SAP system / instance number; making it required would force every caller to pass fake data. RFC-aware plugins (which need it to derive the gateway port 33<sysnr>) set it explicitly. The field is always emitted in to_dict (as null when unset) so plugin authors see a stable wire shape.

- parameters defaults to {} when None is passed, so callers do not have to special-case "no plugin parameters" before calling.
