### PR TITLE
Add bundle activation commands

### DIFF
--- a/doc/commands/activation.md
+++ b/doc/commands/activation.md
@@ -1,12 +1,14 @@
 # Activation
 
 1. [inactiveobjects](#inactiveobjects)
+2. [objects](#objects)
 
 ## inactiveobjects
 
 Deals with Inactive Objects
 
 1. [list](#list)
+2. [activate](#activate)
 
 ### list
 
@@ -14,4 +16,64 @@ List of all inactive objects
 
 ```bash
 sapcli activation inactiveobjects list
+```
+
+### activate
+
+Activate every object currently in the user's inactive worklist in a
+single ADT activation request. Submitting all related inactive objects
+together lets the kernel resolve cross-references in one transaction,
+which is what the per-object CLI activation cannot do.
+
+```bash
+sapcli activation inactiveobjects activate [--dry-run] [--ignore-errors] [--warning-errors]
+```
+
+* _--dry-run_, _-n_ list the objects that would be activated, then exit
+* _--ignore-errors_ return success even if activation reports errors
+* _--warning-errors_ treat activation warnings as errors
+
+## objects
+
+Activate a specific set of named objects.
+
+1. [activate](#activate-1)
+
+### activate
+
+Bundle-activate the explicit list of objects passed via repeated
+`--object KIND=NAME` flags. Same single-request semantics as
+`inactiveobjects activate`, useful when you want to activate only a
+subset of your worklist or when ABAP objects you have just edited are
+not yet visible in the worklist.
+
+```bash
+sapcli activation objects activate --object KIND=NAME [--object KIND=NAME ...] [--list-kinds] [--dry-run] [--ignore-errors] [--warning-errors]
+```
+
+* _--object KIND=NAME_ add an object to the bundle (repeat for multiple)
+* _--list-kinds_ print the supported KINDs and exit
+* _--dry-run_, _-n_ list the objects that would be activated, then exit
+* _--ignore-errors_ return success even if activation reports errors
+* _--warning-errors_ treat activation warnings as errors
+
+Supported KINDs: `program` (alias `prog`), `include` (`incl`), `class`
+(`clas`), `interface` (`intf`), `function-group` (`fugr`),
+`function-module` (`fm`), `function-include`, `data-element`
+(`dtel`), `domain` (`doma`), `table` (`tabl`), `structure` (`stru`),
+`behavior-definition` (`bdef`), `message-class` (`msag`),
+`transaction` (`tran`).
+
+Examples:
+
+```bash
+# class definition include + its implementation include
+sapcli activation objects activate \
+    --object include=YOUR_INCLUDE_01 \
+    --object include=YOUR_INCLUDE_02
+
+# class + the interface it implements
+sapcli activation objects activate \
+    --object class=YOUR_CLASS \
+    --object interface=YOUR_INTERFACE
 ```

--- a/sap/cli/activation.py
+++ b/sap/cli/activation.py
@@ -1,10 +1,63 @@
-"""ADT proxy for Object Activation routines"""
+"""ADT proxy for Object Activation routines."""
 
 import sap.cli.core
-from sap.adt.wb import fetch_inactive_objects
+import sap.errors
+
+from sap.adt.objects import ADTObjectReferences, Class, Interface
+from sap.adt.programs import Program, Include
+from sap.adt.function import FunctionGroup, FunctionModule, FunctionInclude
+from sap.adt.dataelement import DataElement
+from sap.adt.domain import Domain
+from sap.adt.table import Table
+from sap.adt.structure import Structure
+from sap.adt.behaviordefinition import BehaviorDefinition
+from sap.adt.messageclass import MessageClass
+from sap.adt.transaction import Transaction
+from sap.adt.wb import fetch_inactive_objects, mass_activate
 from sap.cli.core import printout
 
 
+# ---------------------------------------------------------------------------
+# Object-kind registry: maps a short CLI name (and a couple of common ABAP
+# aliases) to the ADT object class. ``objects activate`` looks the class up
+# here, instantiates it with (connection, name) and adds the resulting
+# ADTObject to an ADTObjectReferences via ``add_object`` - the same routine
+# ``try_activate`` uses internally for the single-object path.
+# ---------------------------------------------------------------------------
+KIND_REGISTRY = {
+    'program': Program,
+    'prog': Program,
+    'include': Include,
+    'incl': Include,
+    'class': Class,
+    'clas': Class,
+    'interface': Interface,
+    'intf': Interface,
+    'function-group': FunctionGroup,
+    'fugr': FunctionGroup,
+    'function-module': FunctionModule,
+    'fm': FunctionModule,
+    'function-include': FunctionInclude,
+    'data-element': DataElement,
+    'dtel': DataElement,
+    'domain': Domain,
+    'doma': Domain,
+    'table': Table,
+    'tabl': Table,
+    'structure': Structure,
+    'stru': Structure,
+    'behavior-definition': BehaviorDefinition,
+    'bdef': BehaviorDefinition,
+    'message-class': MessageClass,
+    'msag': MessageClass,
+    'transaction': Transaction,
+    'tran': Transaction,
+}
+
+
+# ---------------------------------------------------------------------------
+# argparse sub-groups
+# ---------------------------------------------------------------------------
 class InactiveObjectsGroup(sap.cli.core.CommandGroup):
     """Container for inactive objects commands."""
 
@@ -12,50 +65,67 @@ class InactiveObjectsGroup(sap.cli.core.CommandGroup):
         super().__init__('inactiveobjects')
 
 
+class ObjectsGroup(sap.cli.core.CommandGroup):
+    """Container for explicit object-set commands."""
+
+    def __init__(self):
+        super().__init__('objects')
+
+
 class CommandGroup(sap.cli.core.CommandGroup):
-    """Adapter converting command line parameters to sap.adt.wb.*
-       methods calls.
-    """
+    """Adapter converting command line parameters to sap.adt.wb.* calls."""
 
     def __init__(self):
         super().__init__('activation')
 
         self.inactive_objects_grp = InactiveObjectsGroup()
+        self.objects_grp = ObjectsGroup()
 
     def install_parser(self, arg_parser):
         activation_group = super().install_parser(arg_parser)
 
         inobj_parser = activation_group.add_parser(self.inactive_objects_grp.name)
-
         self.inactive_objects_grp.install_parser(inobj_parser)
 
+        obj_parser = activation_group.add_parser(self.objects_grp.name)
+        self.objects_grp.install_parser(obj_parser)
 
-@InactiveObjectsGroup.command('list')
-# pylint: disable=unused-argument
-def inactiveobjects_list(connection, args):
-    """Print out all inactive objects"""
 
-    def print_entry(entry, prefix=''):
-        printout(f'{prefix}{entry.object.name} ({entry.object.typ})')
+# ---------------------------------------------------------------------------
+# Helpers shared by all commands in this module
+# ---------------------------------------------------------------------------
+def _print_entry(entry, prefix=''):
+    """Pretty-print a single inactive-objects entry."""
 
-    inactive_results = fetch_inactive_objects(connection)
+    printout(f'{prefix}{entry.object.name} ({entry.object.typ})')
+
+
+def _walk_inactive(inactive_results, callback):
+    """Iterate inactive_results.entries with parent-then-child ordering.
+
+    Mirrors the structure already used by ``inactiveobjects list`` so
+    that output and reference collection share the same traversal.
+    """
 
     handled = set()
 
     for root_entry in inactive_results.entries:
+        if root_entry.object is None:
+            continue
         if root_entry.object.parent_uri:
             continue
 
-        root_entry_uri = root_entry.object.uri
-        if root_entry_uri in handled:
+        root_uri = root_entry.object.uri
+        if root_uri in handled:
             continue
 
-        print_entry(root_entry)
-
-        handled.add(root_entry_uri)
+        callback(root_entry, '')
+        handled.add(root_uri)
 
         for child_entry in inactive_results.entries:
-            if root_entry_uri != child_entry.object.parent_uri:
+            if child_entry.object is None:
+                continue
+            if root_uri != child_entry.object.parent_uri:
                 continue
 
             child_uri = child_entry.object.uri
@@ -63,11 +133,180 @@ def inactiveobjects_list(connection, args):
                 continue
 
             handled.add(child_uri)
-            print_entry(child_entry, prefix=' + ')
+            callback(child_entry, ' + ')
 
     for leftover_entry in inactive_results.entries:
+        if leftover_entry.object is None:
+            continue
+
         leftover_uri = leftover_entry.object.uri
         if leftover_uri in handled:
             continue
 
-        print_entry(leftover_entry)
+        callback(leftover_entry, '')
+
+
+def _report_results(results, ignore_errors, warning_errors):
+    """Print activation messages and return an exit code (0 ok, 1 fail)."""
+
+    if results.has_errors or (results.has_warnings and warning_errors):
+        if results.has_errors:
+            printout('Activation reported errors:')
+        else:
+            printout('Activation reported warnings (treated as errors):')
+
+        for message in results.messages:
+            printout(f'  {message.typ} {message.obj_descr}: {message.short_text}')
+
+        if not ignore_errors:
+            return 1
+    elif results.has_warnings:
+        printout('Activation reported warnings:')
+        for message in results.messages:
+            if message.is_warning:
+                printout(f'  W {message.obj_descr}: {message.short_text}')
+
+    printout('Activation finished.')
+    return 0
+
+
+def _parse_object_spec(spec):
+    """Parse a ``KIND=NAME`` argument value into ``(kind, name)``."""
+
+    if '=' not in spec:
+        raise sap.errors.SAPCliError(
+            f"Invalid --object value '{spec}'. Expected KIND=NAME.")
+
+    kind, name = spec.split('=', 1)
+    kind = kind.strip().lower()
+    name = name.strip()
+
+    if not kind or not name:
+        raise sap.errors.SAPCliError(
+            f"Invalid --object value '{spec}'. Both KIND and NAME must be non-empty.")
+
+    if kind not in KIND_REGISTRY:
+        supported = ', '.join(sorted(KIND_REGISTRY))
+        raise sap.errors.SAPCliError(
+            f"Unsupported object kind '{kind}'. Supported kinds: {supported}.")
+
+    return kind, name
+
+
+# ---------------------------------------------------------------------------
+# Commands: activation inactiveobjects ...
+# ---------------------------------------------------------------------------
+@InactiveObjectsGroup.command('list')
+# pylint: disable=unused-argument
+def inactiveobjects_list(connection, args):
+    """Print out all inactive objects"""
+
+    inactive_results = fetch_inactive_objects(connection)
+    _walk_inactive(inactive_results, _print_entry)
+
+
+@InactiveObjectsGroup.argument('--dry-run', '-n', action='store_true', default=False,
+                               help='List the objects that would be activated, then exit')
+@InactiveObjectsGroup.argument('--warning-errors', action='store_true', default=False,
+                               help='Treat activation warnings as errors')
+@InactiveObjectsGroup.argument('--ignore-errors', action='store_true', default=False,
+                               help='Return success even if activation reports errors')
+@InactiveObjectsGroup.command('activate')
+def inactiveobjects_activate(connection, args):
+    """Activate everything in the user's inactive worklist in one ADT request.
+
+    Submits the entire worklist as one ADT activation request, so
+    cross-references between currently-inactive siblings are resolved
+    by the kernel in a single transaction.
+    """
+
+    inactive_results = fetch_inactive_objects(connection)
+
+    refs = ADTObjectReferences()
+    seen_uris = set()
+
+    def collect(entry, _prefix):
+        if entry.object is None:
+            return
+        if entry.object.deleted == 'true':
+            return
+        ref = entry.object.reference
+        if not ref.uri or ref.uri in seen_uris:
+            return
+        seen_uris.add(ref.uri)
+        refs.references.append(ref)
+
+    _walk_inactive(inactive_results, collect)
+
+    if not refs.references:
+        printout('No inactive objects.')
+        return 0
+
+    printout(f'Activating {len(refs.references)} object(s):')
+    for ref in refs.references:
+        printout(f'  {ref.name} ({ref.typ})')
+
+    if args.dry_run:
+        printout('Dry run - nothing was sent to the server.')
+        return 0
+
+    results, _resp = mass_activate(connection, refs)
+    return _report_results(results, args.ignore_errors, args.warning_errors)
+
+
+# ---------------------------------------------------------------------------
+# Commands: activation objects ...
+# ---------------------------------------------------------------------------
+@ObjectsGroup.argument('--dry-run', '-n', action='store_true', default=False,
+                       help='List the objects that would be activated, then exit')
+@ObjectsGroup.argument('--warning-errors', action='store_true', default=False,
+                       help='Treat activation warnings as errors')
+@ObjectsGroup.argument('--ignore-errors', action='store_true', default=False,
+                       help='Return success even if activation reports errors')
+@ObjectsGroup.argument('--object', dest='objects', action='append',
+                       metavar='KIND=NAME',
+                       help='Add an object to the bundle (repeat for multiple). '
+                            'Examples: --object program=YOUR_PROGRAM '
+                            '--object include=YOUR_INCLUDE. '
+                            'Run with --list-kinds to see all supported KINDs.')
+@ObjectsGroup.argument('--list-kinds', action='store_true', default=False,
+                       help='Print the list of supported KINDs and exit')
+@ObjectsGroup.command('activate')
+def objects_activate(connection, args):
+    """Bundle-activate a specific set of named objects in one ADT request.
+
+    Use repeated ``--object KIND=NAME`` flags to enumerate the bundle.
+    Like ``inactiveobjects activate``, the kernel resolves cross-references
+    in a single transaction so cross-referencing inactive objects are
+    activated together.
+    """
+
+    if args.list_kinds:
+        printout('Supported KINDs:')
+        for kind in sorted(KIND_REGISTRY):
+            printout(f'  {kind:20s} -> {KIND_REGISTRY[kind].__name__}')
+        return 0
+
+    if not args.objects:
+        raise sap.errors.SAPCliError(
+            'At least one --object KIND=NAME is required unless --list-kinds is used.')
+
+    refs = ADTObjectReferences()
+    summary = []   # list of (kind, name) for printout/dry-run
+
+    for spec in args.objects:
+        kind, name = _parse_object_spec(spec)
+        obj = KIND_REGISTRY[kind](connection, name)
+        refs.add_object(obj)
+        summary.append((kind, name))
+
+    printout(f'Activating {len(summary)} object(s):')
+    for kind, name in summary:
+        printout(f'  {kind} {name}')
+
+    if args.dry_run:
+        printout('Dry run - nothing was sent to the server.')
+        return 0
+
+    results, _resp = mass_activate(connection, refs)
+    return _report_results(results, args.ignore_errors, args.warning_errors)

--- a/test/unit/test_sap_cli_activation.py
+++ b/test/unit/test_sap_cli_activation.py
@@ -106,5 +106,254 @@ FAKE (SAPCLI/PYTEST)
 """)
 
 
+class TestInactiveobjectsActivate(unittest.TestCase):
+
+    @patch('sap.cli.activation.mass_activate')
+    @patch('sap.cli.activation.fetch_inactive_objects')
+    def test_no_inactive_objects(self, fake_fetch, fake_mass):
+        conn = Mock()
+
+        fake_fetch.return_value = sap.adt.wb.IOCList()
+
+        args = INACTIVEOBJECTS_PARSER.parse('activate')
+
+        with patch_get_print_console_with_buffer() as fake_console:
+            rc = args.execute(conn, args)
+
+        self.assertEqual(rc, 0)
+        fake_mass.assert_not_called()
+        self.assertIn('No inactive objects.', fake_console.capout)
+
+    @patch('sap.cli.activation.mass_activate')
+    @patch('sap.cli.activation.fetch_inactive_objects')
+    def test_two_entries_are_sent_in_one_request(self, fake_fetch, fake_mass):
+        conn = Mock()
+
+        builder = IOCObjectListBuilder()
+        builder.add_class('CL_FIRST')
+        builder.add_class('CL_SECOND')
+        fake_fetch.return_value = builder.objects
+
+        results = Mock()
+        results.has_errors = False
+        results.has_warnings = False
+        results.messages = []
+        fake_mass.return_value = (results, Mock())
+
+        args = INACTIVEOBJECTS_PARSER.parse('activate')
+
+        with patch_get_print_console_with_buffer() as fake_console:
+            rc = args.execute(conn, args)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake_mass.call_count, 1)
+        sent_refs = fake_mass.call_args.args[1]
+        self.assertEqual(len(sent_refs.references), 2)
+        self.assertIn('Activating 2 object(s):', fake_console.capout)
+        self.assertIn('Activation finished.', fake_console.capout)
+
+    @patch('sap.cli.activation.mass_activate')
+    @patch('sap.cli.activation.fetch_inactive_objects')
+    def test_deleted_entries_are_skipped(self, fake_fetch, fake_mass):
+        conn = Mock()
+
+        builder = IOCObjectListBuilder()
+        builder.add_class('CL_KEEP')
+        deleted = builder.add_class('CL_DELETED')
+        deleted.object.deleted = 'true'
+        fake_fetch.return_value = builder.objects
+
+        results = Mock()
+        results.has_errors = False
+        results.has_warnings = False
+        results.messages = []
+        fake_mass.return_value = (results, Mock())
+
+        args = INACTIVEOBJECTS_PARSER.parse('activate')
+
+        with patch_get_print_console_with_buffer() as fake_console:
+            args.execute(conn, args)
+
+        sent_refs = fake_mass.call_args.args[1]
+        self.assertEqual(len(sent_refs.references), 1)
+        self.assertEqual(sent_refs.references[0].name, 'CL_KEEP')
+
+        # The printed listing must reflect the filtered set that is actually
+        # sent to mass_activate; the deleted entry must not appear.
+        self.assertIn('Activating 1 object(s):', fake_console.capout)
+        self.assertIn('CL_KEEP', fake_console.capout)
+        self.assertNotIn('CL_DELETED', fake_console.capout)
+
+    @patch('sap.cli.activation.mass_activate')
+    @patch('sap.cli.activation.fetch_inactive_objects')
+    def test_dry_run_does_not_call_mass_activate(self, fake_fetch, fake_mass):
+        conn = Mock()
+
+        builder = IOCObjectListBuilder()
+        builder.add_class('CL_FOO')
+        fake_fetch.return_value = builder.objects
+
+        args = INACTIVEOBJECTS_PARSER.parse('activate', '--dry-run')
+
+        with patch_get_print_console_with_buffer() as fake_console:
+            rc = args.execute(conn, args)
+
+        self.assertEqual(rc, 0)
+        fake_mass.assert_not_called()
+        self.assertIn('Dry run', fake_console.capout)
+
+    @patch('sap.cli.activation.mass_activate')
+    @patch('sap.cli.activation.fetch_inactive_objects')
+    def test_errors_return_one(self, fake_fetch, fake_mass):
+        conn = Mock()
+
+        builder = IOCObjectListBuilder()
+        builder.add_class('CL_FOO')
+        fake_fetch.return_value = builder.objects
+
+        message = Mock()
+        message.typ = 'E'
+        message.obj_descr = 'CL_FOO'
+        message.short_text = 'syntax error'
+        message.is_warning = False
+        message.is_error = True
+
+        results = Mock()
+        results.has_errors = True
+        results.has_warnings = False
+        results.messages = [message]
+        fake_mass.return_value = (results, Mock())
+
+        args = INACTIVEOBJECTS_PARSER.parse('activate')
+
+        with patch_get_print_console_with_buffer():
+            rc = args.execute(conn, args)
+
+        self.assertEqual(rc, 1)
+
+    @patch('sap.cli.activation.mass_activate')
+    @patch('sap.cli.activation.fetch_inactive_objects')
+    def test_ignore_errors_returns_zero(self, fake_fetch, fake_mass):
+        conn = Mock()
+
+        builder = IOCObjectListBuilder()
+        builder.add_class('CL_FOO')
+        fake_fetch.return_value = builder.objects
+
+        message = Mock()
+        message.typ = 'E'
+        message.obj_descr = 'CL_FOO'
+        message.short_text = 'syntax error'
+        message.is_warning = False
+        message.is_error = True
+
+        results = Mock()
+        results.has_errors = True
+        results.has_warnings = False
+        results.messages = [message]
+        fake_mass.return_value = (results, Mock())
+
+        args = INACTIVEOBJECTS_PARSER.parse('activate', '--ignore-errors')
+
+        with patch_get_print_console_with_buffer():
+            rc = args.execute(conn, args)
+
+        self.assertEqual(rc, 0)
+
+
+OBJECTS_PARSER = GroupArgumentParser(sap.cli.activation.ObjectsGroup)
+
+
+class TestObjectsActivate(unittest.TestCase):
+
+    def test_list_kinds_short_circuits(self):
+        conn = Mock()
+
+        args = OBJECTS_PARSER.parse('activate', '--list-kinds')
+
+        with patch_get_print_console_with_buffer() as fake_console:
+            rc = args.execute(conn, args)
+
+        self.assertEqual(rc, 0)
+        self.assertIn('Supported KINDs:', fake_console.capout)
+        self.assertIn('program', fake_console.capout)
+
+    def test_missing_object_without_list_kinds_raises(self):
+        conn = Mock()
+
+        args = OBJECTS_PARSER.parse('activate')
+
+        with patch_get_print_console_with_buffer():
+            with self.assertRaises(sap.errors.SAPCliError):
+                args.execute(conn, args)
+
+    @patch('sap.cli.activation.mass_activate')
+    def test_two_objects_sent_in_one_request(self, fake_mass):
+        conn = Connection()
+
+        results = Mock()
+        results.has_errors = False
+        results.has_warnings = False
+        results.messages = []
+        fake_mass.return_value = (results, Mock())
+
+        args = OBJECTS_PARSER.parse(
+            'activate',
+            '--object', 'program=ZMYREP',
+            '--object', 'include=ZMYREP_C01'
+        )
+
+        with patch_get_print_console_with_buffer() as fake_console:
+            rc = args.execute(conn, args)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake_mass.call_count, 1)
+        sent_refs = fake_mass.call_args.args[1]
+        self.assertEqual(len(sent_refs.references), 2)
+        self.assertIn('Activating 2 object(s):', fake_console.capout)
+
+    def test_unknown_kind_raises_sapclierror(self):
+        conn = Mock()
+
+        args = OBJECTS_PARSER.parse('activate', '--object', 'foobar=ZX')
+
+        with patch_get_print_console_with_buffer():
+            with self.assertRaises(sap.errors.SAPCliError):
+                args.execute(conn, args)
+
+    def test_malformed_spec_raises_sapclierror(self):
+        conn = Mock()
+
+        args = OBJECTS_PARSER.parse('activate', '--object', 'no-equals-sign')
+
+        with patch_get_print_console_with_buffer():
+            with self.assertRaises(sap.errors.SAPCliError):
+                args.execute(conn, args)
+
+    @patch('sap.cli.activation.mass_activate')
+    def test_dry_run_does_not_call_mass_activate(self, fake_mass):
+        conn = Connection()
+
+        args = OBJECTS_PARSER.parse(
+            'activate', '--dry-run', '--object', 'program=ZMYREP'
+        )
+
+        with patch_get_print_console_with_buffer() as fake_console:
+            rc = args.execute(conn, args)
+
+        self.assertEqual(rc, 0)
+        fake_mass.assert_not_called()
+        self.assertIn('Dry run', fake_console.capout)
+
+    def test_alias_resolves_to_same_class(self):
+        # The CLI accepts both canonical and ABAP aliases
+        self.assertIs(sap.cli.activation.KIND_REGISTRY['program'],
+                      sap.cli.activation.KIND_REGISTRY['prog'])
+        self.assertIs(sap.cli.activation.KIND_REGISTRY['include'],
+                      sap.cli.activation.KIND_REGISTRY['incl'])
+        self.assertIs(sap.cli.activation.KIND_REGISTRY['class'],
+                      sap.cli.activation.KIND_REGISTRY['clas'])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Why**

Activating a single inactive object via the existing CLI (e.g. `sapcli include activate ZMYREP_C02`) issues one ADT request that is processed by the kernel in isolation. As soon as several inactive objects reference each other, the kernel sees the siblings as still inactive and the activation aborts — the same pattern shows up between a class definition and its implementation in two includes, between a class and the interface it implements, between a CDS DDL and a consumer that imports it, and so on.

Eclipse ADT does not have this problem because the IDE submits all related inactive objects in a single ADT request and the kernel resolves cross-references in one transaction. The library function `sap.adt.wb.mass_activate` already implements exactly that protocol; this PR makes it reachable from the CLI.

**Two new commands**

* `sapcli activation inactiveobjects activate` — activates everything in the user's inactive worklist.
* `sapcli activation objects activate --object KIND=NAME [--object KIND=NAME ...]` — activates an explicit set. `--list-kinds` prints the supported KIND values.

Both commands accept `--dry-run` / `-n`, `--ignore-errors`, `--warning-errors`. The existing `inactiveobjects list` is preserved (the original logic is split into `_walk_inactive` + `_print_entry` helpers, which produce byte-identical output).

**Before / after**

Two inactive includes that reference each other (a class definition include and its implementation include).

Before — per-object CLI activates them in isolation and the kernel sees the sibling as still inactive:

    $ sapcli include activate ZMYREP_LCL
    * ZMYREP_LCL
    -- Include ZMYREP_LCL
       E: Implementation missing for method "DUMMY_METHOD".
    Activation has stopped
    Errors: 1

With this PR — both objects are submitted in a single activation request:

    $ sapcli activation objects activate \
          --object include=ZMYREP_LCL \
          --object include=ZMYREP_C02
    Activating 2 object(s):
      include ZMYREP_LCL
      include ZMYREP_C02
    Activation finished.

**Local checks**

* `make lint` clean for `sap/cli/activation.py` (pylint 10.00/10, flake8 0 issues).
* `make test` passes the same baseline as upstream master on this machine; `test_sap_cli_activation` runs 13 tests (1 existing + 12 new), all green.
* The change is pure CLI surface — no new third-party dependency, no kernel-side change, no new ADT endpoint.
