### PR TITLE
http/tls: trust system certificates by default

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -65,6 +65,36 @@ can use the switch `--skip-ssl-validation` to suppress all certificate checks
 when connecting to your server. Same behavior can be achieved by setting the
 environment variable `SAP_SSL_VERIFY` to `no`.
 
+### --ssl-no-system-certs
+
+By default sapcli validates server certificates against the operating system
+trust store, so a root CA added via `update-ca-certificates` (see above), the
+Windows Certificate Store or the macOS Keychain is honoured automatically. This
+covers the sapcli HTTP traffic that targets the SAP system (ADT, REST/gCTS,
+OData and OAuth token retrieval). It does not affect downloading a remote
+configuration file (`--config <URL>`), because that download happens before the
+connection options are resolved.
+
+The switch `--ssl-no-system-certs` opts out and validates certificates against
+the CA bundle shipped with the `certifi` package instead. The same behavior can
+be achieved by setting the environment variable `SAP_SSL_USE_SYSTEM_CERTS` to a
+false value (`no`, `false`, `off`) or the connection setting
+`ssl_use_system_certs` to `false`.
+
+The operating system trust store is not consulted when validation is disabled
+(`--skip-ssl-validation`) or when an explicit CA bundle is supplied with
+`--ssl-server-cert`; the explicit bundle then takes precedence.
+
+This behavior relies on the
+[truststore](https://pypi.org/project/truststore/) package, which is installed
+automatically as a regular sapcli dependency. Should it ever be missing (an
+incomplete installation), sapcli logs a warning and falls back to the bundled
+certifi CA list.
+
+Unlike `--skip-ssl-validation`, the operating system trust store keeps
+certificate validation enabled - it only changes where the trusted CAs are read
+from.
+
 ### --port
 
 TCP PORT where your SAP Application Server accepts connection for ICF services.
@@ -245,6 +275,7 @@ See [OAuth 2.0 authentication](#oauth-20-authentication) below for details.
 | `ssl` | bool | no | `true` | `SAP_SSL` |
 | `ssl_verify` | bool | no | `true` | `SAP_SSL_VERIFY` |
 | `ssl_server_cert` | string | no | - | `SAP_SSL_SERVER_CERT` |
+| `ssl_use_system_certs` | bool | no | `true` | `SAP_SSL_USE_SYSTEM_CERTS` |
 | `mshost` | string | no (*) | - | `SAP_MSHOST` |
 | `msserv` | string | no | - | `SAP_MSSERV` |
 | `sysid` | string | no | - | `SAP_SYSID` |
@@ -746,6 +777,9 @@ targeting different systems. It also composes well with tools like
 - `SAP_PASSWORD` : default value for the command line parameter --password
 - `SAP_SSL_SERVER_CERT` : path to the public unencrypted server SSL certificate
 - `SAP_SSL_VERIFY` : if "no", SSL server certificate is no validated - this works only when SAP_SSL_SERVER_CERT is not configured
+- `SAP_SSL_USE_SYSTEM_CERTS` : SSL server certificates are validated against the
+   operating system trust store by default; set this to a false value (no, false,
+   off - case insensitive) to fall back to the bundled certifi CA list
 - `SAP_TOKEN_URL` : base URL of the OAuth 2.0 authorization server; corresponds to `connections.<name>.token_url` (enables OAuth authentication; see [OAuth 2.0 authentication](#oauth-20-authentication))
 - `SAP_CLIENT_ID` : OAuth 2.0 client ID; corresponds to `connections.<name>.client_id`
 - `SAP_CLIENT_SECRET` : OAuth 2.0 client secret; corresponds to `connections.<name>.client_secret`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pyodata>=1.7.0",
     "PyYAML>=6.0.1",
     "platformdirs>=4.5.1",
+    "truststore>=0.10.4",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.20.0
 pyodata==1.7.0
 PyYAML==6.0.1
 platformdirs>=4.5.1
+truststore>=0.10.4

--- a/sap/cli/__init__.py
+++ b/sap/cli/__init__.py
@@ -417,8 +417,7 @@ def resolve_default_connection_values(args):
         else:
             args.verify = True
 
-    if not args.ssl_server_cert:
-        args.ssl_server_cert = os.getenv('SAP_SSL_SERVER_CERT') or config_values.get('ssl_server_cert')
+    _resolve_ssl_cert_defaults(args, config_values)
 
     if not args.user:
         args.user = os.getenv('SAP_USER') or config_values.get('user')
@@ -436,6 +435,22 @@ def resolve_default_connection_values(args):
     # Apply config file values for message server / SNC params
     # that may not have been set by env vars in parse_command_line
     _apply_config_extra_params(args, config_values)
+
+
+def _resolve_ssl_cert_defaults(args, config_values):
+    """Resolve SSL certificate source defaults from env vars and config file."""
+
+    if not args.ssl_server_cert:
+        args.ssl_server_cert = os.getenv('SAP_SSL_SERVER_CERT') or config_values.get('ssl_server_cert')
+
+    if getattr(args, 'ssl_use_system_certs', None) is None:
+        use_system_certs = os.getenv('SAP_SSL_USE_SYSTEM_CERTS')
+        if use_system_certs is not None:
+            args.ssl_use_system_certs = use_system_certs.lower() not in _FALSE_TOKENS
+        elif 'ssl_use_system_certs' in config_values:
+            args.ssl_use_system_certs = _normalize_bool(config_values['ssl_use_system_certs'])
+        else:
+            args.ssl_use_system_certs = True
 
 
 def _resolve_oauth_defaults(args, config_values):

--- a/sap/cli/_entry.py
+++ b/sap/cli/_entry.py
@@ -16,6 +16,7 @@ import sap.adt
 import sap.rfc
 from sap.config import ConfigFile
 from sap.http import TimedOutRequestError as HttpTimedOutRequestError
+from sap.http.truststore_support import enable_system_cert_store, TruststoreNotAvailableError
 import sap.http.oauth
 from sap.odata.errors import TimedOutRequestError as ODataTimedOutRequestError
 
@@ -43,6 +44,23 @@ def report_args_error_and_exit(args, error):
     print(error, file=sys.stderr)
     args.print_help(sys.stderr)
     sys.exit(ExitCodes.INVALID_CONFIGURATION)
+
+
+def _system_cert_store_applies(args):
+    """Whether the operating system trust store should back TLS verification.
+
+    True only when sapcli actually verifies a server certificate over TLS and no
+    explicit CA bundle was supplied - otherwise enabling the OS trust store is
+    either a no-op (plain HTTP or validation disabled) or would override the
+    user's explicit --ssl-server-cert choice.
+    """
+
+    return bool(
+        args.ssl_use_system_certs
+        and args.ssl
+        and args.verify
+        and not args.ssl_server_cert
+    )
 
 
 # pylint: disable=too-many-statements
@@ -93,6 +111,10 @@ def parse_command_line(argv):
     arg_parser.add_argument(
         '--ssl-server-cert', dest='ssl_server_cert', type=str, default=None,
         help='Path to a custom CA certificate file for SSL verification')
+    arg_parser.add_argument(
+        '--ssl-no-system-certs', dest='ssl_use_system_certs', default=None, action='store_false',
+        help='Verify SSL server certificates against the bundled certifi CA list instead '
+             'of the operating system trust store (used by default). Env: SAP_SSL_USE_SYSTEM_CERTS')
     arg_parser.add_argument(
         '--port', dest='port', type=int, default=None,
         help='ADT HTTP port; default = 443')
@@ -147,6 +169,16 @@ def parse_command_line(argv):
         return args
 
     sap.cli.resolve_default_connection_values(args)
+
+    if _system_cert_store_applies(args):
+        try:
+            enable_system_cert_store()
+        except TruststoreNotAvailableError as ex:
+            # truststore is a regular sapcli dependency, so a failed import means
+            # a broken installation. The operating system trust store is the
+            # default, so do not fail every connection over it - warn and fall
+            # back to the bundled certifi CA list.
+            log.warning('%s', ex)
 
     if not args.ashost and not args.mshost:
         report_args_error_and_exit(

--- a/sap/config.py
+++ b/sap/config.py
@@ -21,7 +21,7 @@ class SAPCliConfigError(SAPCliError):
 
 CONNECTION_FIELDS = (
     'ashost', 'sysnr', 'client', 'port', 'ssl', 'ssl_verify',
-    'ssl_server_cert', 'mshost', 'msserv', 'sysid', 'group',
+    'ssl_server_cert', 'ssl_use_system_certs', 'mshost', 'msserv', 'sysid', 'group',
     'snc_qop', 'snc_myname', 'snc_partnername', 'snc_lib',
     'token_url', 'client_id', 'client_secret',
 )

--- a/sap/http/truststore_support.py
+++ b/sap/http/truststore_support.py
@@ -1,0 +1,53 @@
+"""Verify TLS server certificates against the operating system trust store.
+
+By default Python requests validates server certificates against the CA bundle
+shipped with the certifi package, ignoring CAs installed into the operating
+system (e.g. corporate root CAs added via update-ca-certificates, the Windows
+Certificate Store or the macOS Keychain).
+
+The optional truststore package bridges that gap: a single inject_into_ssl()
+call makes the whole ssl/urllib3/requests stack validate against the OS trust
+store, so it covers every sapcli HTTP path (ADT, REST/gCTS, OData, OAuth token
+fetch and remote config download) at once.
+"""
+
+from sap import get_logger
+from sap.errors import SAPCliError
+
+
+class TruststoreNotAvailableError(SAPCliError):
+    """Raised when the OS trust store was requested but truststore is missing."""
+
+    def __init__(self):
+        super().__init__(
+            'Cannot verify SSL certificates against the operating system trust '
+            'store: the "truststore" package could not be imported. It is a '
+            'regular sapcli dependency, so this usually means the installation '
+            'is incomplete; reinstall sapcli (or run: pip install truststore)')
+
+
+# Non-empty once inject_into_ssl() has run; guards against injecting twice.
+_INJECTED: list = []
+
+
+def enable_system_cert_store():
+    """Make Python requests verify TLS server certificates against the operating
+       system trust store instead of the bundled certifi CA list.
+
+       Idempotent: repeated calls inject only once.
+
+       Raises TruststoreNotAvailableError when the truststore package cannot be
+       imported.
+    """
+
+    if _INJECTED:
+        return
+
+    try:
+        import truststore
+    except ImportError as ex:
+        raise TruststoreNotAvailableError() from ex
+
+    truststore.inject_into_ssl()
+    _INJECTED.append(True)
+    get_logger().info('Verifying SSL certificates against the operating system trust store')

--- a/test/unit/test_sap_cli.py
+++ b/test/unit/test_sap_cli.py
@@ -120,6 +120,7 @@ class TestResolveDefaultConnectionValuesWithConfigFile(unittest.TestCase):
         defaults = dict(
             ashost=None, sysnr=None, client=None, port=None,
             ssl=None, verify=None, ssl_server_cert=None,
+            ssl_use_system_certs=None,
             user=None, password=None,
         )
         defaults.update(kwargs)
@@ -720,6 +721,76 @@ class TestResolveDefaultConnectionValuesWithConfigFile(unittest.TestCase):
             sap.cli.resolve_default_connection_values(args)
 
         self.assertIsNone(args.ssl_server_cert)
+
+    def test_ssl_use_system_certs_default_true(self):
+        """ssl_use_system_certs defaults to True when not provided anywhere."""
+        args = self._make_args()
+
+        with patch.dict('os.environ', {}, clear=True):
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertTrue(args.ssl_use_system_certs)
+
+    def test_ssl_use_system_certs_disabled_via_config_file(self):
+        """Config file can opt out by setting ssl_use_system_certs to False."""
+        config_data = {
+            'current-context': 'dev',
+            'connections': {
+                'dev-server': {
+                    'ashost': 'host.example.com',
+                    'client': '100',
+                    'ssl_use_system_certs': False,
+                },
+            },
+            'users': {
+                'dev-user': {'user': 'USR', 'password': 'PWD'},
+            },
+            'contexts': {
+                'dev': {'connection': 'dev-server', 'user': 'dev-user'},
+            },
+        }
+        config_file = ConfigFile(config_data, TEST_CONFIG_PATH)
+        args = self._make_args(config_file=config_file)
+
+        with patch.dict('os.environ', {}, clear=True):
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertFalse(args.ssl_use_system_certs)
+
+    def test_ssl_use_system_certs_env_overrides_config(self):
+        """SAP_SSL_USE_SYSTEM_CERTS env var takes precedence over config file."""
+        config_data = {
+            'current-context': 'dev',
+            'connections': {
+                'dev-server': {
+                    'ashost': 'host.example.com',
+                    'client': '100',
+                    'ssl_use_system_certs': True,
+                },
+            },
+            'users': {
+                'dev-user': {'user': 'USR', 'password': 'PWD'},
+            },
+            'contexts': {
+                'dev': {'connection': 'dev-server', 'user': 'dev-user'},
+            },
+        }
+        config_file = ConfigFile(config_data, TEST_CONFIG_PATH)
+        args = self._make_args(config_file=config_file)
+
+        with patch.dict('os.environ', {'SAP_SSL_USE_SYSTEM_CERTS': 'no'}, clear=True):
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertFalse(args.ssl_use_system_certs)
+
+    def test_ssl_use_system_certs_cli_overrides_env(self):
+        """CLI --ssl-no-system-certs takes precedence over env var."""
+        args = self._make_args(ssl_use_system_certs=False)
+
+        with patch.dict('os.environ', {'SAP_SSL_USE_SYSTEM_CERTS': 'yes'}, clear=True):
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertFalse(args.ssl_use_system_certs)
 
 
 class TestNoConnection(unittest.TestCase):

--- a/test/unit/test_sap_cli__entry.py
+++ b/test/unit/test_sap_cli__entry.py
@@ -8,6 +8,7 @@ from io import StringIO
 import sap
 import sap.cli._entry as entry
 from sap.config import ConfigFile
+from sap.http.truststore_support import TruststoreNotAvailableError
 from sap.rest.errors import TimedOutRequestError as RestTimedOutRequestError
 from sap.odata.errors import TimedOutRequestError as ODataTimedOutRequestError
 
@@ -50,6 +51,19 @@ def get_tested_parameters():
     """Return ALL_PARAMETERS with the mock command and subcommand appended."""
 
     return ALL_PARAMETERS + [MOCK_COMMAND_NAME, MOCK_SUBCOMMAND_NAME]
+
+
+def get_tls_verifying_parameters():
+    """Tested parameters with TLS enabled and certificate validation on.
+
+    ALL_PARAMETERS disables both (--no-ssl, --skip-ssl-validation); drop them so
+    the operating system trust store is actually consulted.
+    """
+
+    params = get_tested_parameters()
+    params.remove('--no-ssl')
+    params.remove('--skip-ssl-validation')
+    return params
 
 
 class TestParseCommandLine(unittest.TestCase):
@@ -347,6 +361,63 @@ class TestParseCommandLine(unittest.TestCase):
         args = entry.parse_command_line(test_params)
 
         self.assertIsNone(args.ssl_server_cert)
+
+    def test_args_system_certs_enabled_by_default(self):
+        """Without any flag the operating system trust store is used."""
+        test_params = get_tls_verifying_parameters()
+
+        with patch('sap.cli._entry.enable_system_cert_store') as fake_enable:
+            args = entry.parse_command_line(test_params)
+
+        self.assertTrue(args.ssl_use_system_certs)
+        fake_enable.assert_called_once_with()
+
+    def test_args_ssl_no_system_certs_flag(self):
+        """--ssl-no-system-certs opts out of the operating system trust store."""
+        test_params = get_tls_verifying_parameters()
+        test_params.insert(1, '--ssl-no-system-certs')
+
+        with patch('sap.cli._entry.enable_system_cert_store') as fake_enable:
+            args = entry.parse_command_line(test_params)
+
+        self.assertFalse(args.ssl_use_system_certs)
+        fake_enable.assert_not_called()
+
+    def test_args_system_certs_skipped_when_validation_disabled(self):
+        """With --skip-ssl-validation there is nothing to verify against."""
+        test_params = get_tls_verifying_parameters()
+        test_params.insert(1, '--skip-ssl-validation')
+
+        with patch('sap.cli._entry.enable_system_cert_store') as fake_enable:
+            args = entry.parse_command_line(test_params)
+
+        self.assertTrue(args.ssl_use_system_certs)
+        fake_enable.assert_not_called()
+
+    def test_args_system_certs_skipped_with_custom_ca(self):
+        """An explicit --ssl-server-cert takes precedence over the OS store."""
+        test_params = get_tls_verifying_parameters()
+        test_params.insert(1, '/path/to/ca.pem')
+        test_params.insert(1, '--ssl-server-cert')
+
+        with patch('sap.cli._entry.enable_system_cert_store') as fake_enable:
+            args = entry.parse_command_line(test_params)
+
+        self.assertTrue(args.ssl_use_system_certs)
+        fake_enable.assert_not_called()
+
+    def test_args_system_certs_missing_truststore_warns_and_continues(self):
+        """A broken truststore install must not break every connection."""
+        test_params = get_tls_verifying_parameters()
+
+        with patch('sap.cli._entry.enable_system_cert_store',
+                   side_effect=TruststoreNotAvailableError()) as fake_enable, \
+                patch('sap.cli._entry.log') as fake_log:
+            args = entry.parse_command_line(test_params)
+
+        self.assertTrue(args.ssl_use_system_certs)
+        fake_enable.assert_called_once_with()
+        fake_log.warning.assert_called_once()
 
     def test_args_auth_plugin_disable_cache_default_false(self):
         """Without the flag and without env, the resolved value is False


### PR DESCRIPTION
I did not know that system CA certs must be manually imported into request tls layer because only ABAP system that I use are corporate ones and their TLS certs are signed by private CAs and I just disabled the TLS cert validation.

This patch should automatically make the system CA certs trusted.o

If you do not like it, you can opt out (this option exist just for backward compatibility and I am not even sure it is worth it but LLM wrote it initially ...).