### PR TITLE
gcts: refactor simple.py to allow smoother re-use

### DIFF
--- a/sap/rest/gcts/repo_task.py
+++ b/sap/rest/gcts/repo_task.py
@@ -1,6 +1,6 @@
 """Utilities for gCTS repository tasks"""
 
-from typing import Optional
+from typing import Optional, List
 from enum import Enum
 from sap import get_logger
 
@@ -9,10 +9,15 @@ from sap.http import HTTPRequestError
 
 from sap.rest.gcts.errors import (
     SAPCliError,
+    GCTSProcessError,
     GCTSRequestError,
     GCTSRepoCloneError,
     GCTSRepoNotExistsError,
     GCTSRepoCloneTaskDeleteError,
+)
+
+from sap.rest.gcts.log_messages import (
+    ProcessMessage,
 )
 
 
@@ -53,6 +58,15 @@ def exception_from_http_error_for_task(http_error):
         return GCTSRepoCloneTaskDeleteError(messages)
 
     return GCTSRequestError(messages)
+
+
+def raise_for_process_message_error(process_messages: List[ProcessMessage]):
+    """Checks the list of process messages for any with severity 'ERROR' and
+       raises GCTSProcessError if found.
+    """
+
+    if any(message.severity == 'ERROR' for message in process_messages):
+        raise GCTSProcessError(process_messages=process_messages)
 
 
 class _TaskHttpProxy:

--- a/sap/rest/gcts/simple.py
+++ b/sap/rest/gcts/simple.py
@@ -2,7 +2,7 @@
 
 import json
 import time
-from typing import Optional
+from typing import Optional, List
 
 from sap import get_logger
 from sap.errors import OperationTimeoutError
@@ -11,11 +11,16 @@ from sap.rest.gcts.remote_repo import (
     Repository,
     RepoMessagesQueryParams,
 )
-from sap.rest.gcts.repo_task import RepositoryTask
+from sap.rest.gcts.repo_task import (
+    raise_for_process_message_error,
+    RepositoryTask
+)
+from sap.rest.gcts.log_messages import (
+    ProcessMessage
+)
 from sap.rest.gcts.errors import (
     exception_from_http_error,
     GCTSRepoAlreadyExistsError,
-    GCTSProcessError,
     SAPCliError,
 )
 from sap.rest.gcts.sugar import (
@@ -135,6 +140,24 @@ def clone(connection, url, rid, vsid='6IT', start_dir='src/', vcs_token=None,
     return repo
 
 
+def fetch_process_messages_for_task(repo: Repository, task: RepositoryTask) -> List[ProcessMessage]:
+    """Simple helper that ensures fetching process messages for the given task
+       log returns exactly 1 message containing the process messages, otherwise
+       raises an error.
+    """
+
+    repo_messages = repo.messages(RepoMessagesQueryParams().set_process(task.log))
+
+    if len(repo_messages) != 1:
+        raise SAPCliError(f'Expected just 1 log message: {len(repo_messages)}')
+
+    process_messages = repo_messages[0].process_messages
+    if not process_messages:
+        raise SAPCliError(f'No process messages found for task log: {task.log}')
+
+    return process_messages
+
+
 # pylint: disable=too-many-locals
 def clone_with_task(connection, url, rid, vsid='6IT', start_dir='src/', vcs_token=None,
                     error_exists=True, role='SOURCE', typ='GITHUB', no_import=False,
@@ -183,15 +206,8 @@ def clone_with_task(connection, url, rid, vsid='6IT', start_dir='src/', vcs_toke
                 progress_consumer.progress_message(f'CLONE task "{task.tid}" has finished successfully.')
                 progress_consumer.progress_message(f'Checking Job Log "{task.log}" ...')
 
-            repo_messages = repo.messages(RepoMessagesQueryParams().set_process(task.log))
-
-            if len(repo_messages) != 1:
-                raise SAPCliError(f'Expected just 1 log message: {len(repo_messages)}')
-
-            process_messages = repo_messages[0].process_messages
-            for message in process_messages:
-                if message.severity == 'ERROR':
-                    raise GCTSProcessError(process_messages=process_messages)
+            process_messages = fetch_process_messages_for_task(repo, task)
+            raise_for_process_message_error(process_messages)
         else:
             raise OperationTimeoutError
 

--- a/test/unit/test_sap_rest_gcts.py
+++ b/test/unit/test_sap_rest_gcts.py
@@ -8,12 +8,14 @@ from unittest.mock import Mock, MagicMock, ANY, call, patch
 import sap.errors
 from sap.rest.errors import HTTPRequestError, UnauthorizedError
 from sap.rest.gcts.errors import GCTSProcessError
-from sap.rest.gcts.repo_task import RepositoryTask
+from sap.rest.gcts.repo_task import RepositoryTask, raise_for_process_message_error
 import sap.rest.gcts
 import sap.rest.gcts.remote_repo
 import sap.rest.gcts.simple
 import sap.rest.gcts.sugar
 import sap.rest.gcts.log_messages
+from sap.rest.gcts.log_messages import ProcessMessage
+from sap.rest.gcts.simple import fetch_process_messages_for_task
 
 from mock import Request, Response, RESTConnection, make_gcts_log_error
 from mock import GCTSLogBuilder as LogBuilder
@@ -1923,6 +1925,55 @@ class TestRepositoryTask(unittest.TestCase):
         self.assertEqual(get_request.adt_uri, f'repository/{self.rid}/task/{task_id}')
 
 
+class TestRaiseForProcessMessageError(unittest.TestCase):
+
+    def test_raises_on_first_error_message(self):
+        """raise_for_process_message_error raises GCTSProcessError on first ERROR severity"""
+        messages = [
+            ProcessMessage({'action': 'EXECUTE_JOB', 'severity': 'RUNNING', 'application': 'gCTS', 'applInfo': 'started'}),
+            ProcessMessage({'action': 'FINISH_JOB', 'severity': 'ERROR', 'application': 'gCTS', 'applInfo': 'failed'}),
+            ProcessMessage({'action': 'CLONE', 'severity': 'ERROR', 'application': 'gCTS', 'applInfo': 'clone error'}),
+        ]
+
+        with self.assertRaises(GCTSProcessError) as cm:
+            raise_for_process_message_error(messages)
+
+        self.assertIs(cm.exception.process_messages, messages)
+
+    def test_does_not_raise_when_no_error_messages(self):
+        """raise_for_process_message_error does nothing if no ERROR severity messages"""
+        messages = [
+            ProcessMessage({'action': 'EXECUTE_JOB', 'severity': 'RUNNING', 'application': 'gCTS', 'applInfo': 'started'}),
+            ProcessMessage({'action': 'FINISH_JOB', 'severity': 'FINISHED', 'application': 'gCTS', 'applInfo': 'done'}),
+            ProcessMessage({'action': 'LOG_LEVEL', 'severity': 'INFO', 'application': 'gCTS', 'applInfo': 'info'}),
+        ]
+
+        raise_for_process_message_error(messages)
+
+    def test_does_not_raise_for_empty_list(self):
+        """raise_for_process_message_error does nothing for empty list"""
+        raise_for_process_message_error([])
+
+    def test_raises_with_single_error_message(self):
+        """raise_for_process_message_error raises on single ERROR message"""
+        messages = [
+            ProcessMessage({'action': 'CLONE', 'severity': 'ERROR', 'application': 'gCTS', 'applInfo': 'error'}),
+        ]
+
+        with self.assertRaises(GCTSProcessError) as cm:
+            raise_for_process_message_error(messages)
+
+        self.assertIs(cm.exception.process_messages, messages)
+
+    def test_does_not_raise_for_warning_severity(self):
+        """raise_for_process_message_error ignores WARNING severity"""
+        messages = [
+            ProcessMessage({'action': 'GET_CURRENT_COMMIT', 'severity': 'WARNING', 'application': 'gCTS', 'applInfo': 'warn'}),
+        ]
+
+        raise_for_process_message_error(messages)
+
+
 class TestRepoActivitiesQueryParams(unittest.TestCase):
 
     def setUp(self):
@@ -3318,6 +3369,117 @@ class TestgCTSSimpleAPI(GCTSTestSetUp, unittest.TestCase):
             ),
             self
         )
+
+
+class TestFetchProcessMessagesForTask(GCTSTestSetUp, unittest.TestCase):
+
+    def test_returns_process_messages_for_single_log_entry(self):
+        """fetch_process_messages_for_task returns process messages when exactly 1 log message"""
+        repo_data = dict(self.repo_server_data)
+        repo = sap.rest.gcts.remote_repo.Repository(self.conn, self.repo_rid, data=repo_data)
+
+        task_log = '9617D6AFE539F5AF388E74AA8EE92196'
+        task = RepositoryTask(self.conn, self.repo_rid, data={'tid': '123', 'log': task_log})
+
+        self.conn.set_responses(
+            Response.with_json(json=CLONE_SUCCESS_PROCESS_MESSAGES_RESPONSE, status_code=200),
+        )
+
+        result = fetch_process_messages_for_task(repo, task)
+
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, list)
+        self.assertTrue(len(result) > 0)
+        self.assertIsInstance(result[0], ProcessMessage)
+
+    def test_raises_when_response_has_zero_messages(self):
+        """fetch_process_messages_for_task raises SAPCliError when empty response returned"""
+        repo_data = dict(self.repo_server_data)
+        repo = sap.rest.gcts.remote_repo.Repository(self.conn, self.repo_rid, data=repo_data)
+
+        task_log = '9617D6AFE539F5AF388E74AA8EE92196'
+        task = RepositoryTask(self.conn, self.repo_rid, data={'tid': '123', 'log': task_log})
+
+        self.conn.set_responses(
+            Response.with_json(json={}, status_code=200),
+        )
+
+        with self.assertRaises(sap.errors.SAPCliError) as cm:
+            fetch_process_messages_for_task(repo, task)
+
+        self.assertIn('Expected just 1 log message: 0', str(cm.exception))
+
+    def test_raises_when_repo_messages_returns_multiple_entries(self):
+        """fetch_process_messages_for_task raises SAPCliError when more than 1 ActionMessage returned"""
+        repo_data = dict(self.repo_server_data)
+        repo = sap.rest.gcts.remote_repo.Repository(self.conn, self.repo_rid, data=repo_data)
+
+        task_log = '9617D6AFE539F5AF388E74AA8EE92196'
+        task = RepositoryTask(self.conn, self.repo_rid, data={'tid': '123', 'log': task_log})
+
+        fake_action_msg_1 = Mock()
+        fake_action_msg_1.process_messages = [ProcessMessage({'action': 'A', 'severity': 'INFO', 'application': 'gCTS', 'applInfo': 'x'})]
+        fake_action_msg_2 = Mock()
+        fake_action_msg_2.process_messages = [ProcessMessage({'action': 'B', 'severity': 'ERROR', 'application': 'gCTS', 'applInfo': 'y'})]
+
+        with patch.object(repo, 'messages', return_value=[fake_action_msg_1, fake_action_msg_2]):
+            with self.assertRaises(sap.errors.SAPCliError) as cm:
+                fetch_process_messages_for_task(repo, task)
+
+        self.assertIn('Expected just 1 log message: 2', str(cm.exception))
+
+    def test_calls_repo_messages_with_correct_process(self):
+        """fetch_process_messages_for_task passes the task log to the query params"""
+        repo_data = dict(self.repo_server_data)
+        repo = sap.rest.gcts.remote_repo.Repository(self.conn, self.repo_rid, data=repo_data)
+
+        task_log = 'ABCDEF1234567890'
+        task = RepositoryTask(self.conn, self.repo_rid, data={'tid': '456', 'log': task_log})
+
+        self.conn.set_responses(
+            Response.with_json(json=CLONE_SUCCESS_PROCESS_MESSAGES_RESPONSE, status_code=200),
+        )
+
+        fetch_process_messages_for_task(repo, task)
+
+        self.assertEqual(len(self.conn.execs), 1)
+        request = self.conn.execs[0]
+        self.assertEqual(request.method, 'GET')
+        self.assertIn(task_log, request.adt_uri)
+
+    def test_raises_when_process_messages_is_none(self):
+        """fetch_process_messages_for_task raises SAPCliError when process_messages is None"""
+        repo_data = dict(self.repo_server_data)
+        repo = sap.rest.gcts.remote_repo.Repository(self.conn, self.repo_rid, data=repo_data)
+
+        task_log = '9617D6AFE539F5AF388E74AA8EE92196'
+        task = RepositoryTask(self.conn, self.repo_rid, data={'tid': '123', 'log': task_log})
+
+        fake_action_msg = Mock()
+        fake_action_msg.process_messages = None
+
+        with patch.object(repo, 'messages', return_value=[fake_action_msg]):
+            with self.assertRaises(sap.errors.SAPCliError) as cm:
+                fetch_process_messages_for_task(repo, task)
+
+        self.assertIn(f'No process messages found for task log: {task_log}', str(cm.exception))
+
+    def test_raises_when_process_messages_is_empty_list(self):
+        """fetch_process_messages_for_task raises SAPCliError when process_messages is empty list"""
+        repo_data = dict(self.repo_server_data)
+        repo = sap.rest.gcts.remote_repo.Repository(self.conn, self.repo_rid, data=repo_data)
+
+        task_log = '9617D6AFE539F5AF388E74AA8EE92196'
+        task = RepositoryTask(self.conn, self.repo_rid, data={'tid': '123', 'log': task_log})
+
+        fake_action_msg = Mock()
+        fake_action_msg.process_messages = []
+
+        with patch.object(repo, 'messages', return_value=[fake_action_msg]):
+            with self.assertRaises(sap.errors.SAPCliError) as cm:
+                fetch_process_messages_for_task(repo, task)
+
+        self.assertIn(f'No process messages found for task log: {task_log}', str(cm.exception))
 
 
 class TestCloneStartingFolder(GCTSTestSetUp, unittest.TestCase):


### PR DESCRIPTION
I need some building blocks of Ansible modules where I need different type of reporting and thus I do not use clone_with_task.