### PR TITLE
package: support package types (main/structure) and change-recording on create

### DIFF
--- a/doc/commands/package.md
+++ b/doc/commands/package.md
@@ -12,7 +12,7 @@
 Creates non-transportable packages
 
 ```bash
-sapcli package create [--super-package SUPER_PKG] [--app-component APP_COMP] [--software-component SW_COMP] [--transport-layer TR_LAYER] [--no-error-existing] NAME DESCRIPTION
+sapcli package create [--super-package SUPER_PKG] [--app-component APP_COMP] [--software-component SW_COMP] [--transport-layer TR_LAYER] [--package-type {development,structure,main}] [--no-error-existing] NAME DESCRIPTION
 ```
 
 **Parameters**:
@@ -20,6 +20,7 @@ sapcli package create [--super-package SUPER_PKG] [--app-component APP_COMP] [--
 - `--app-component APP_COMP`: Name of assigned Application Component. **(optional)**
 - `--software-component SW_COMP`: Name of assigned Software Component. **(optional)**
 - `--transport-layer TR_LAYER`: Name of assigned Transport Layer. **(optional)**
+- `--package-type {development,structure,main}`: Package type. Defaults to `development`. **(optional)**
 - `--no-error-existing`: Do not exit with non-0 exit code if the package already exists. **(optional)**
 - `NAME`: Name of the newly created package. Do not forget to escape $ in shell to avoid ENV variable evaluation.
 - `DESCRIPTION`: Description of the newly created package. Do not forget to use " if you need more words.

--- a/doc/commands/package.md
+++ b/doc/commands/package.md
@@ -12,7 +12,7 @@
 Creates non-transportable packages
 
 ```bash
-sapcli package create [--super-package SUPER_PKG] [--app-component APP_COMP] [--software-component SW_COMP] [--transport-layer TR_LAYER] [--package-type {development,structure,main}] [--no-error-existing] NAME DESCRIPTION
+sapcli package create [--super-package SUPER_PKG] [--app-component APP_COMP] [--software-component SW_COMP] [--transport-layer TR_LAYER] [--package-type {development,structure,main}] [--record-changes] [--no-error-existing] NAME DESCRIPTION
 ```
 
 **Parameters**:
@@ -21,6 +21,7 @@ sapcli package create [--super-package SUPER_PKG] [--app-component APP_COMP] [--
 - `--software-component SW_COMP`: Name of assigned Software Component. **(optional)**
 - `--transport-layer TR_LAYER`: Name of assigned Transport Layer. **(optional)**
 - `--package-type {development,structure,main}`: Package type. Defaults to `development`. **(optional)**
+- `--record-changes`: Record changes via transport requests. Required by some structure packages whose `pak:recordChanges` attribute is not editable after creation. **(optional)**
 - `--no-error-existing`: Do not exit with non-0 exit code if the package already exists. **(optional)**
 - `NAME`: Name of the newly created package. Do not forget to escape $ in shell to avoid ENV variable evaluation.
 - `DESCRIPTION`: Description of the newly created package. Do not forget to use " if you need more words.

--- a/sap/adt/package.py
+++ b/sap/adt/package.py
@@ -49,6 +49,7 @@ class Package(ADTObject):
 
         def __init__(self, name=None):
             self._package_type = name
+            self._record_changes = None
 
         @xml_attribute('pak:packageType')
         def package_type(self):
@@ -63,6 +64,24 @@ class Package(ADTObject):
             """
 
             self._package_type = value
+
+        @xml_attribute('pak:recordChanges')
+        def record_changes(self):
+            """Whether the Package records changes via transport requests.
+
+            Returned as the string ``'true'``/``'false'`` to match the wire
+            format expected by the ADT backend, or ``None`` when not set
+            (in which case the attribute is omitted from the XML payload).
+            """
+
+            return self._record_changes
+
+        @record_changes.setter
+        def record_changes(self, value):
+            """The Package's record changes setter
+            """
+
+            self._record_changes = value
 
     class Transport(metaclass=OrderedClassMembers):
         """SAP Package transport details.
@@ -174,6 +193,15 @@ class Package(ADTObject):
         """
 
         self._attributes.package_type = package_type
+
+    def set_record_changes(self, record_changes):
+        """Sets whether the Package records changes via transport requests.
+
+        Accepts a bool; serialized as the lowercase string ``'true'`` /
+        ``'false'`` to match the ADT wire format.
+        """
+
+        self._attributes.record_changes = 'true' if record_changes else 'false'
 
     def set_software_component(self, name):
         """Changes the Package's software component

--- a/sap/cli/package.py
+++ b/sap/cli/package.py
@@ -38,6 +38,9 @@ class CommandGroup(sap.cli.core.CommandGroup):
 @CommandGroup.argument('--software-component', default='LOCAL', help='Software component')
 @CommandGroup.argument('--app-component', default=None, help='Application component')
 @CommandGroup.argument('--super-package', default=None, help='Parent package name')
+@CommandGroup.argument('--package-type', default='development',
+                       choices=['development', 'structure', 'main'],
+                       help='Package type (default: development)')
 @CommandGroup.argument('description')
 @CommandGroup.argument('name')
 @CommandGroup.command()
@@ -49,7 +52,7 @@ def create(connection, args):
 
     package = sap.adt.Package(connection, args.name.upper(), metadata=metadata)
     package.description = args.description
-    package.set_package_type('development')
+    package.set_package_type(args.package_type)
 
     package.set_software_component(args.software_component)
 

--- a/sap/cli/package.py
+++ b/sap/cli/package.py
@@ -34,6 +34,9 @@ class CommandGroup(sap.cli.core.CommandGroup):
 @CommandGroup.argument_corrnr()
 @CommandGroup.argument('--no-error-existing', action='store_true', default=False,
                        help='Do not fail if already exists')
+@CommandGroup.argument('--record-changes', action='store_true', default=False,
+                       help='Record changes via transport requests '
+                            '(required by some structure packages)')
 @CommandGroup.argument('--transport-layer', default=None, help='Transport layer')
 @CommandGroup.argument('--software-component', default='LOCAL', help='Software component')
 @CommandGroup.argument('--app-component', default=None, help='Application component')
@@ -53,6 +56,9 @@ def create(connection, args):
     package = sap.adt.Package(connection, args.name.upper(), metadata=metadata)
     package.description = args.description
     package.set_package_type(args.package_type)
+
+    if args.record_changes:
+        package.set_record_changes(True)
 
     package.set_software_component(args.software_component)
 

--- a/test/unit/test_sap_adt_package.py
+++ b/test/unit/test_sap_adt_package.py
@@ -74,6 +74,41 @@ class TestADTPackage(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(conn.execs[0][3].decode('utf-8'), FIXTURE_PACKAGE_XML)
 
+    def test_package_serialization_with_record_changes_true(self):
+        conn = Connection(collections={'/sap/bc/adt/packages': ['application/vnd.sap.adt.packages.v1+xml']})
+
+        metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', master_system='NPL', responsible='FILAK')
+        package = sap.adt.Package(conn, '$TEST', metadata=metadata)
+        package.description = 'description'
+        package.set_package_type('main')
+        package.set_record_changes(True)
+        package.set_software_component('LOCAL')
+        package.set_transport_layer('HOME')
+        package.set_app_component('PPM')
+        package.super_package.name = '$MASTER'
+        package.create()
+
+        body = conn.execs[0][3].decode('utf-8')
+        self.assertIn('pak:packageType="main"', body)
+        self.assertIn('pak:recordChanges="true"', body)
+
+    def test_package_serialization_with_record_changes_false(self):
+        conn = Connection(collections={'/sap/bc/adt/packages': ['application/vnd.sap.adt.packages.v1+xml']})
+
+        metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', master_system='NPL', responsible='FILAK')
+        package = sap.adt.Package(conn, '$TEST', metadata=metadata)
+        package.description = 'description'
+        package.set_package_type('development')
+        package.set_record_changes(False)
+        package.set_software_component('LOCAL')
+        package.set_transport_layer('HOME')
+        package.set_app_component('PPM')
+        package.super_package.name = '$MASTER'
+        package.create()
+
+        body = conn.execs[0][3].decode('utf-8')
+        self.assertIn('pak:recordChanges="false"', body)
+
     def test_adt_package_fetch(self):
         conn = Connection([Response(text=GET_PACKAGE_ADT_XML,
                                     status_code=200,

--- a/test/unit/test_sap_cli_package.py
+++ b/test/unit/test_sap_cli_package.py
@@ -79,6 +79,34 @@ class TestPackageCreate(unittest.TestCase):
 
         self.assertEqual(connection.execs[0].params['corrNr'], '420')
 
+    def test_create_package_default_type_is_development(self):
+        connection = Connection([EMPTY_RESPONSE_OK])
+
+        args = parse_args('create', '$TEST', 'description')
+        sap.cli.package.create(connection, args)
+
+        self.assertIn('pak:packageType="development"', connection.execs[0].body.decode('utf-8'))
+
+    def test_create_package_with_package_type(self):
+        connection = Connection([EMPTY_RESPONSE_OK])
+
+        args = parse_args('create', 'ZTEST_MAIN', 'description', '--package-type', 'main')
+        sap.cli.package.create(connection, args)
+
+        self.assertIn('pak:packageType="main"', connection.execs[0].body.decode('utf-8'))
+
+    def test_create_package_with_package_type_structure(self):
+        connection = Connection([EMPTY_RESPONSE_OK])
+
+        args = parse_args('create', 'ZTEST_STRUCT', 'description', '--package-type', 'structure')
+        sap.cli.package.create(connection, args)
+
+        self.assertIn('pak:packageType="structure"', connection.execs[0].body.decode('utf-8'))
+
+    def test_create_package_rejects_unknown_package_type(self):
+        with self.assertRaises(SystemExit):
+            parse_args('create', '$TEST', 'description', '--package-type', 'bogus')
+
     def test_create_package_error_exists_ignored(self):
         connection = Connection([RESPONSE_PACKAGE_EXISTS])
 

--- a/test/unit/test_sap_cli_package.py
+++ b/test/unit/test_sap_cli_package.py
@@ -107,6 +107,26 @@ class TestPackageCreate(unittest.TestCase):
         with self.assertRaises(SystemExit):
             parse_args('create', '$TEST', 'description', '--package-type', 'bogus')
 
+    def test_create_package_default_omits_record_changes(self):
+        connection = Connection([EMPTY_RESPONSE_OK])
+
+        args = parse_args('create', '$TEST', 'description')
+        sap.cli.package.create(connection, args)
+
+        body = connection.execs[0].body.decode('utf-8')
+        self.assertNotIn('pak:recordChanges', body)
+
+    def test_create_package_with_record_changes(self):
+        connection = Connection([EMPTY_RESPONSE_OK])
+
+        args = parse_args('create', 'ZTEST_MAIN', 'description',
+                          '--package-type', 'main', '--record-changes')
+        sap.cli.package.create(connection, args)
+
+        body = connection.execs[0].body.decode('utf-8')
+        self.assertIn('pak:packageType="main"', body)
+        self.assertIn('pak:recordChanges="true"', body)
+
     def test_create_package_error_exists_ignored(self):
         connection = Connection([RESPONSE_PACKAGE_EXISTS])
 


### PR DESCRIPTION
## What this PR does

Currently `sapcli package create` cannot produce two kinds of packages that ADT (Eclipse / VS Code) can:

1. **Top-level packages of type `main` or `structure`.** [`sap/cli/package.py`](sap/cli/package.py) hardcoded `package.set_package_type('development')` with no flag to override. Anyone wanting a `main` / `structure` package had to drop down to ADT.
2. **Packages whose parent's transport-recording policy requires `pak:recordChanges="true"` at creation time.** Creating a sub-package under such a parent failed with `ExceptionResourceCreationFailure: Change recording must be activated for package <NAME>`. The attribute is also marked `pak:isRecordChangesEditable="false"` on those trees, so it cannot be flipped after the fact — it must be sent in the initial POST. `sap/adt/package.py` modelled only `pak:packageType` under `<pak:attributes>` and never serialised `pak:recordChanges`.

This PR adds:

- `sapcli package create --package-type {development,structure,main}` (default `development`)
- `sapcli package create --record-changes` (action='store_true', default False)
- `sap.adt.Package.set_record_changes(bool)` API on the ADT layer

## Commits

```
22bc6df cli: package create accepts --package-type
7b8abd3 package: support pak:recordChanges on create
```

Two commits because they are logically distinct changes (per CONTRIBUTING.md "better to create more commits than less"): the first is a pure CLI flag, the second extends the wire format.

## Backward compatibility

Both flags default to the previous behavior, so existing callers/scripts behave unchanged.

The `pak:recordChanges` attribute defaults to `None` on the model object, which the marshaller (`sap/adt/marshalling.py:444` — `if value is not None: root.add_attribute(...)`) skips. As a result:

- `test_init` and `test_package_serialization_v2` in `test/unit/test_sap_adt_package.py` (which assert exact-byte XML payloads) **still pass byte-identically** without modification.
- Every existing call site that doesn't pass the new flag emits the same wire payload as before.

## Tests

- 4 new tests for `--package-type`, 4 new tests for `--record-changes` / `set_record_changes` (split CLI vs ADT layer per AGENTS.md).
- Verified via `red → green` TDD as called for in AGENTS.md.
- Local `python -m unittest discover -s test/unit`: 2670 → **2678** tests, no regressions. Pre-existing failures in `test_sap_cli_config` / `test_sap_config` (4 failures + 16 errors) reproduce identically on `master` in the same environment — they are environmental (Python 3.14 / OS error-message wording in `FileNotFoundError`) and not introduced by this PR.

## Lint

- `pylint --rcfile=.pylintrc sap/cli/package.py sap/adt/package.py` → **10.00/10**
- `flake8 --config=.flake8 sap/cli/package.py sap/adt/package.py` → clean
- Test files: zero new findings vs `master`.

## Live verification

Verified end-to-end against an S/4HANA system:

- Before: creating a sub-package under `CDL_BLACK_DUCK_MAIN` (parent is a structure package with `pak:isRecordChangesEditable="false"`) failed with *"Change recording must be activated for package..."* whether the requested type was `development` or `main`.
- After: with `--package-type main --record-changes`, sapcli sends `<pak:attributes pak:packageType="main" pak:recordChanges="true"/>`, the package is created, and `sapcli package stat` reports `Package Type : main`, `Active : active`.

## Out of scope (for separate PRs)

- `sap/cli/checkin.py:249` also pins `set_package_type('development')`. That follows a different flow (reads metadata from on-disk abapGit XML, which currently doesn't carry a package type). Intentionally separate so this PR stays narrow.
- During testing on the real system I noticed sapcli sends `adtcore:responsible` in whatever case the user has it configured; the SAP backend can require uppercase. This is configuration-side (`sapcli config set-user --user HOERISCH`) and not changed here, but might warrant a defensive `.upper()` somewhere — happy to open a follow-up if desired.
