### PR TITLE
cli: uppercase connection.user when set as adtcore:responsible

### DIFF
--- a/sap/cli/checkin.py
+++ b/sap/cli/checkin.py
@@ -242,7 +242,7 @@ def checkin_package(connection, repo_package, args):
 
     sap.cli.core.printout(f'Creating Package: {repo_package.name} {devc.CTEXT}')
 
-    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user,
+    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user.upper(),
                                    description=devc.CTEXT)
 
     package = sap.adt.Package(connection, repo_package.name.upper(), metadata=metadata)
@@ -302,7 +302,7 @@ def checkin_intf(connection, repo_obj, corrnr=None, check_before_save=False):
     with open(repo_obj.path, encoding='utf-8') as abap_data_file:
         sap.platform.abap.from_xml(abap_data, abap_data_file.read())
 
-    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user,
+    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user.upper(),
                                    description=abap_data.DESCRIPT)
     interface = sap.adt.Interface(connection, repo_obj.name.upper(), package=repo_obj.package.name, metadata=metadata)
 
@@ -332,7 +332,7 @@ def checkin_clas(connection, repo_obj, corrnr=None, check_before_save=False):
     with open(repo_obj.path, encoding='utf-8') as abap_data_file:
         sap.platform.abap.from_xml(abap_data, abap_data_file.read())
 
-    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user,
+    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user.upper(),
                                    description=abap_data.DESCRIPT)
     clas = sap.adt.Class(connection, repo_obj.name.upper(), package=repo_obj.package.name, metadata=metadata)
 
@@ -406,7 +406,7 @@ def checkin_prog(connection, repo_obj, corrnr=None, check_before_save=False):
     # TODO: how to handle CUA?
     tpool = results['TPOOL']
 
-    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user)
+    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user.upper())
     if progdir.SUBC == SUBC_EXECUTABLE_PROGRAM:
         program = sap.adt.Program(connection, repo_obj.name, package=repo_obj.package.name, metadata=metadata)
     elif progdir.SUBC == SUBC_INCLUDE:
@@ -596,7 +596,7 @@ def checkin_fugr(connection, repo_obj, corrnr=None, check_before_save=False):
 
     _check_fugr_source_files(repo_obj, functions, includes)
 
-    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user)
+    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user.upper())
     function_group = sap.adt.FunctionGroup(connection, repo_obj.name.upper(), package=repo_obj.package.name,
                                            metadata=metadata)
     function_group.description = results['AREAT']

--- a/sap/cli/dataelement.py
+++ b/sap/cli/dataelement.py
@@ -183,7 +183,7 @@ def define(connection, args):
 
     console = args.console_factory()
 
-    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user,
+    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user.upper(),
                                    description=args.description)
 
     dataelement = sap.adt.DataElement(connection, args.name.upper(), args.package, metadata=metadata)

--- a/sap/cli/package.py
+++ b/sap/cli/package.py
@@ -45,7 +45,7 @@ def create(connection, args):
     """Creates the requested ABAP package.
     """
 
-    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user)
+    metadata = sap.adt.ADTCoreData(language='EN', master_language='EN', responsible=connection.user.upper())
 
     package = sap.adt.Package(connection, args.name.upper(), metadata=metadata)
     package.description = args.description

--- a/test/unit/test_sap_cli_checkin.py
+++ b/test/unit/test_sap_cli_checkin.py
@@ -557,7 +557,7 @@ class TestCheckInPackage(ConsoleOutputTestCase, PatcherTestCase):
 
         self.assertConsoleContents(self.console,
                                    stdout=f'Creating Package: {self.repo.packages[0].name} Test Package\n')
-        fake_core_data.assert_called_once_with(language='EN', master_language='EN', responsible='fake_user',
+        fake_core_data.assert_called_once_with(language='EN', master_language='EN', responsible='FAKE_USER',
                                                description='Test Package')
         fake_package.assert_called_once_with(self.connection, self.repo.packages[0].name.upper(),
                                              metadata=metadata)
@@ -650,7 +650,7 @@ class TestCheckInClass(PatcherTestCase, ConsoleOutputTestCase):
         sap.cli.checkin.checkin_clas(self.connection, self.clas_object)
 
         self.fake_core_data.assert_called_once_with(language='EN', master_language='EN',
-                                                    responsible=self.connection.user, description='Test description')
+                                                    responsible=self.connection.user.upper(), description='Test description')
         self.fake_class.assert_called_once_with(self.connection, self.clas_object.name.upper(),
                                                 package=self.package.name, metadata=self.metadata)
         self.clas.create.assert_called_once_with(None)
@@ -799,7 +799,7 @@ class TestCheckInInterface(PatcherTestCase, ConsoleOutputTestCase):
         sap.cli.checkin.checkin_intf(self.connection, self.interface_object)
 
         self.fake_core_data.assert_called_once_with(language='EN', master_language='EN',
-                                                    responsible=self.connection.user, description='Test intf descr')
+                                                    responsible=self.connection.user.upper(), description='Test intf descr')
         self.fake_interface.assert_called_once_with(self.connection, self.interface_object.name.upper(),
                                                     package=self.package.name, metadata=self.metadata)
         self.interface.create.assert_called_once_with(None)
@@ -894,7 +894,7 @@ class TestCheckInProgram(PatcherTestCase, ConsoleOutputTestCase):
 
         self.assertEqual(str(cm.exception), 'Unknown program type X')
         self.fake_core_data.assert_called_once_with(language='EN', master_language='EN',
-                                                    responsible=self.connection.user)
+                                                    responsible=self.connection.user.upper())
         self.fake_program.assert_not_called()
         self.fake_include.assert_not_called()
 
@@ -904,7 +904,7 @@ class TestCheckInProgram(PatcherTestCase, ConsoleOutputTestCase):
         sap.cli.checkin.checkin_prog(self.connection, self.prog_object)
 
         self.fake_core_data.assert_called_once_with(language='EN', master_language='EN',
-                                                    responsible=self.connection.user)
+                                                    responsible=self.connection.user.upper())
         self.fake_program.assert_called_once_with(self.connection, self.prog_object.name, package=self.package.name,
                                                   metadata=self.metadata)
         self.assertEqual(self.program.description, 'Test program desc')
@@ -921,7 +921,7 @@ Writing Program: {self.prog_object.name}
         sap.cli.checkin.checkin_prog(self.connection, self.prog_object)
 
         self.fake_core_data.assert_called_once_with(language='EN', master_language='EN',
-                                                    responsible=self.connection.user)
+                                                    responsible=self.connection.user.upper())
         self.fake_program.assert_called_once_with(self.connection, self.prog_object.name, package=self.package.name,
                                                   metadata=self.metadata)
         self.assertEqual(self.program.description, 'Test program desc')
@@ -934,7 +934,7 @@ Writing Program: {self.prog_object.name}
         sap.cli.checkin.checkin_prog(self.connection, self.prog_object)
 
         self.fake_core_data.assert_called_once_with(language='EN', master_language='EN',
-                                                    responsible=self.connection.user)
+                                                    responsible=self.connection.user.upper())
         self.fake_include.assert_called_once_with(self.connection, self.prog_object.name, package=self.package.name,
                                                   metadata=self.metadata)
         self.assertEqual(self.include.description, 'Test include desc')
@@ -1094,7 +1094,7 @@ class TestCheckInFunctionGroup(PatcherTestCase, ConsoleOutputTestCase):
 
         self.assertEqual(inactive_objects, [self.function_group, self.function_include, self.function_module])
 
-        self.fake_core_data.assert_called_once_with(language='EN', master_language='EN', responsible=self.connection.user)
+        self.fake_core_data.assert_called_once_with(language='EN', master_language='EN', responsible=self.connection.user.upper())
         self.fake_function_group.assert_called_once_with(self.connection, 'TEST_FUGR', package=self.fugr_object.package.name,
                                                          metadata=self.metadata)
         self.fake_function_module.assert_called_once_with(self.connection, 'TEST_FUNCTION_MODULE', self.function_group.name,

--- a/test/unit/test_sap_cli_package.py
+++ b/test/unit/test_sap_cli_package.py
@@ -99,6 +99,20 @@ class TestPackageCreate(unittest.TestCase):
         with self.assertRaises(ExceptionResourceAlreadyExists):
             sap.cli.package.create(connection, args)
 
+    def test_create_package_uppercases_responsible_user(self):
+        # The ADT backend rejects lowercase usernames in adtcore:responsible
+        # with "Enter a valid user, not <name>, as the person responsible".
+        # Other CLI handlers (object.py, messageclass.py, function.py) already
+        # call .upper() on connection.user; this brings package.create() in line.
+        connection = Connection([EMPTY_RESPONSE_OK], user='lowercase_user')
+
+        args = parse_args('create', '$TEST', 'description')
+        sap.cli.package.create(connection, args)
+
+        body = connection.execs[0].body.decode('utf-8')
+        self.assertIn('adtcore:responsible="LOWERCASE_USER"', body)
+        self.assertNotIn('adtcore:responsible="lowercase_user"', body)
+
 
 class TestPackageList(PatcherTestCase, ConsoleOutputTestCase):
 


### PR DESCRIPTION
## What this PR does

`sapcli` already calls `connection.user.upper()` when assigning `adtcore:responsible` on object creation in [`sap/cli/object.py:378`](sap/cli/object.py#L378), [`sap/cli/messageclass.py:25`](sap/cli/messageclass.py#L25), and [`sap/cli/function.py:38`/`112`](sap/cli/function.py#L38). The same treatment was missing from three other CLI handlers, and on systems where `connection.user` arrives lowercased (SSO-derived contexts, `sapcli config set-user --user hoerisch`, etc.) the ADT backend rejects the create with:

```
ExceptionResourceCreationFailure: Enter a valid user, not hoerisch, as the person responsible
```

This PR brings the missing call sites in line:

| File | Sites fixed |
|---|---|
| `sap/cli/package.py` | 1 |
| `sap/cli/dataelement.py` | 1 |
| `sap/cli/checkin.py` | 5 |

Net production diff: **7 lines, each gaining `.upper()`**.

## Symptom in the wild

Reproduced against an S/4HANA system. Even with the parent and transport-layer settings correct, `sapcli package create CDL_NEW_MAIN ...` failed with:

```
Exception (ExceptionResourceCreationFailure):
  Enter a valid user, not hoerisch, as the person responsible
```

Configuring the user in uppercase via `sapcli config set-user <name> --user HOERISCH` is a viable workaround, but the case is essentially irrelevant for ABAP user identifiers — uppercasing in the CLI handler matches what the rest of the codebase already does and removes a footgun.

## Tests

- New regression test in `test/unit/test_sap_cli_package.py`: constructs a `Connection` with `user='lowercase_user'`, runs `sap.cli.package.create()`, asserts the request body carries `adtcore:responsible="LOWERCASE_USER"` and not the lowercase form.
- 8 existing assertions in `test/unit/test_sap_cli_checkin.py` were asserting the *old (broken) behavior* — `responsible='fake_user'` / `responsible=self.connection.user`. These are updated to their uppercase counterparts to reflect the new (correct) behavior. The change is mechanical and visible in the diff.

`python -m unittest discover -b -s test/unit`: master 2670 → branch **2671** (+1 new regression test). The 4 failures + 16 errors that exist on `master` are unrelated environmental issues in `test_sap_cli_config` / `test_sap_config` (Python 3.14 / OS error-message wording in `FileNotFoundError`); they reproduce identically on unmodified `master`.

## Lint

`pylint --rcfile=.pylintrc sap/cli/{package,checkin,dataelement}.py` → **10.00/10**. `flake8` clean.

## Note about #171

This is intentionally a **separate, smaller PR** rather than a third commit on [#171](../pull/171). The two changes are unrelated: #171 adds new flags to the package-create CLI surface, this PR fixes a long-standing inconsistency in how the codebase handles `connection.user` across multiple CLI modules. Reviewing them separately keeps each PR focused and lets them land independently.

If preferred I can rebase this onto #171's branch instead — let me know.
