### PR TITLE
errors: model ExceptionResourceLockConflict and ExceptionResourceNoAccess as typed exceptions

### DIFF
--- a/sap/adt/errors.py
+++ b/sap/adt/errors.py
@@ -56,6 +56,41 @@ class ExceptionResourceCreationFailure(ADTError):
         return f'{self.message}'
 
 
+class ExceptionResourceLockConflict(ADTError):
+    """Raised when an ADT resource cannot be modified because the
+       lock state of the resource (or a parent like a software
+       component / package) does not permit it.
+
+       Common message text is
+         'No suitable software component is modifiable; cannot create object'
+       seen on package or DDIC create calls under a parent that is
+       not modifiable for the current user.
+    """
+
+    def __init__(self, message):
+        super().__init__('com.sap.adt', self.__class__.__name__, message)
+
+    def __str__(self):
+        return f'{self.message}'
+
+
+class ExceptionResourceNoAccess(ADTError):
+    """Raised when the calling user has no access to the addressed
+       resource or transport request.
+
+       Common message text on gCTS-managed systems is
+         'Request <T> cannot be used since it is not assigned to repository <R>'
+       which means the object's gCTS repository binding rejects the
+       transport the caller picked (or the implicit one).
+    """
+
+    def __init__(self, message):
+        super().__init__('com.sap.adt', self.__class__.__name__, message)
+
+    def __str__(self):
+        return f'{self.message}'
+
+
 class ExceptionCheckinFailure(SAPCliError):
     """Wrapper for checkin errors"""
 

--- a/test/unit/fixtures_adt.py
+++ b/test/unit/fixtures_adt.py
@@ -141,6 +141,12 @@ ERROR_XML_PACKAGE_ALREADY_EXISTS='''<?xml version="1.0" encoding="utf-8"?><exc:e
 ERROR_XML_PROGRAM_ALREADY_EXISTS='''<?xml version="1.0" encoding="utf-8"?><exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><namespace id="com.sap.adt"/><type id="ExceptionResourceCreationFailure"/><message lang="EN">A program or include already exists with the name SAPCLI_TEST_REPORT.</message><localizedMessage lang="EN">A program or include already exists with the name SAPCLI_TEST_REPORT.</localizedMessage><properties/></exc:exception>'''
 
 
+ERROR_XML_LOCK_CONFLICT='''<?xml version="1.0" encoding="utf-8"?><exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><namespace id="com.sap.adt"/><type id="ExceptionResourceLockConflict"/><message lang="EN">No suitable software component is modifiable; cannot create object</message><localizedMessage lang="EN">No suitable software component is modifiable; cannot create object</localizedMessage><properties/></exc:exception>'''
+
+
+ERROR_XML_RESOURCE_NO_ACCESS='''<?xml version="1.0" encoding="utf-8"?><exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><namespace id="com.sap.adt"/><type id="ExceptionResourceNoAccess"/><message lang="EN">Request DEVK900042 cannot be used since it is not assigned to repository sapcli_test_repo</message><localizedMessage lang="EN">Request DEVK900042 cannot be used since it is not assigned to repository sapcli_test_repo</localizedMessage><properties/></exc:exception>'''
+
+
 ERROR_XML_MADEUP_PROBLEM='''<?xml version="1.0" encoding="utf-8"?><exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communicationframework"><namespace id="org.example.whatever"/><type id="UnitTestSAPCLI"/><message lang="EN">Made up problem.</message><localizedMessage lang="EN">Made up problem.</localizedMessage><properties/></exc:exception>'''
 
 DISCOVERY_ADT_XML = '''<?xml version="1.0" encoding="utf-8"?>

--- a/test/unit/test_sap_adt_errors.py
+++ b/test/unit/test_sap_adt_errors.py
@@ -7,7 +7,9 @@ import sap.adt.errors
 from fixtures_adt import (
     ERROR_XML_PACKAGE_ALREADY_EXISTS,
     ERROR_XML_PROGRAM_ALREADY_EXISTS,
-    ERROR_XML_MADEUP_PROBLEM
+    ERROR_XML_MADEUP_PROBLEM,
+    ERROR_XML_LOCK_CONFLICT,
+    ERROR_XML_RESOURCE_NO_ACCESS
 )
 
 from fixtures_adt_package import GET_PACKAGE_ADT_XML_NOT_FOUND
@@ -63,6 +65,28 @@ class TestADTError(unittest.TestCase):
         self.assertEqual(str(error), 'UnitTestSAPCLI: Made up problem.')
         self.assertEqual(repr(error), 'org.example.whatever.UnitTestSAPCLI')
         self.assertIsInstance(error, sap.adt.errors.ADTError)
+
+    def test_parse_lock_conflict(self):
+        error = sap.adt.errors.new_adt_error_from_xml(ERROR_XML_LOCK_CONFLICT)
+
+        self.assertEqual(error.namespace, 'com.sap.adt')
+        self.assertEqual(error.type, 'ExceptionResourceLockConflict')
+        self.assertEqual(error.message, 'No suitable software component is modifiable; cannot create object')
+
+        self.assertEqual(str(error), error.message)
+        self.assertEqual(repr(error), 'com.sap.adt.ExceptionResourceLockConflict')
+        self.assertIsInstance(error, sap.adt.errors.ExceptionResourceLockConflict)
+
+    def test_parse_resource_no_access(self):
+        error = sap.adt.errors.new_adt_error_from_xml(ERROR_XML_RESOURCE_NO_ACCESS)
+
+        self.assertEqual(error.namespace, 'com.sap.adt')
+        self.assertEqual(error.type, 'ExceptionResourceNoAccess')
+        self.assertEqual(error.message, 'Request DEVK900042 cannot be used since it is not assigned to repository sapcli_test_repo')
+
+        self.assertEqual(str(error), error.message)
+        self.assertEqual(repr(error), 'com.sap.adt.ExceptionResourceNoAccess')
+        self.assertIsInstance(error, sap.adt.errors.ExceptionResourceNoAccess)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What this PR does

`new_adt_error_from_xml()` in `sap/adt/errors.py` walks `ADTError.__subclasses__()` to map the SAP-side exception type id back to a Python class. Adding a typed wrapper for an ADT exception is therefore a one-line declaration — the dispatcher finds it by name automatically.

Four exception types were already typed (`ExceptionResourceAlreadyExists`, `ExceptionResourceNotFound`, `ExceptionResourceCreationFailure`, `ExceptionResourceSaveFailure`). Two more are reachable on ordinary CLI flows on modern S/4HANA (Cloud and gCTS-managed) systems but were falling through to the generic `ADTError`. This PR adds them.

## The two new exceptions

### `ExceptionResourceLockConflict`

Raised when the ADT backend rejects a create/modify because the lock state of the addressed resource — or one of its parents like a software component or package — does not allow the change.

**Reproducer** (live HTTP capture, just now):
```
HTTP 409 Conflict
<type id="ExceptionResourceLockConflict"/>
<message lang="EN">No suitable software component is modifiable; cannot create object</message>
```
Triggered by:
```bash
sapcli package create ZCDL_LOCK_REPRO "..." \
  --super-package CDL_BLACK_DUCK_MAIN --software-component INFRA_HOME \
  --transport-layer ZY6T --corrnr <T>
```
…on a S/4HANA system where the parent package is not modifiable for the calling user.

### `ExceptionResourceNoAccess`

Raised when the calling user has no access to the addressed resource or transport request. On gCTS-managed systems the typical message form is `Request <T> cannot be used since it is not assigned to repository <R>`.

**Reproducer** (live HTTP capture, just now):
```
HTTP 403 Forbidden
<type id="ExceptionResourceNoAccess"/>
<message lang="EN">Request C50K900020 cannot be used since it is not assigned to repository <REPO></message>
```
Triggered by:
```bash
sapcli class write <CLASS_OWNED_BY_DIFFERENT_REPO_USER> ...
```
…on a gCTS-managed system where the class belongs to a repository the calling user is not in scope for.

The fixture in this PR uses sanitised placeholder names (`DEVK900042`, `sapcli_test_repo`) so no SAP-internal identifiers leak to the public repo.

## Backward compatibility

Net additive. `except ADTError:` blocks continue to match — the new classes inherit from `ADTError` unchanged. Code that already does typed dispatch on the four older exceptions is unaffected.

## Tests

New tests follow the existing `test_parse_existing_package` shape one-for-one in `test/unit/test_sap_adt_errors.py`.

`python -m unittest discover -b -s test/unit`: master 2699 → branch **2701** (+2 new tests). The 4 failures + 16 errors that exist on `master` are pre-existing environmental issues in `test_sap_cli_config` / `test_sap_config` (Python 3.14 / OS error-message wording in `FileNotFoundError`); they reproduce identically on unmodified `master`.

## Lint

`pylint --rcfile=.pylintrc sap/adt/errors.py` → **10.00/10**.
`flake8 --config=.flake8 sap/adt/errors.py` → clean.

The two new fixture entries in `test/unit/fixtures_adt.py` use the existing `NAME='...'` no-space convention of that file (rather than PEP-8 `NAME = '...'`) for diff locality with the surrounding fixtures. Happy to switch on review request.

## Net diff

```
sap/adt/errors.py                | 35 +++++++++++++++++++++++++++++++++++
test/unit/fixtures_adt.py        |  6 ++++++
test/unit/test_sap_adt_errors.py | 26 +++++++++++++++++++++++++-
3 files changed, 66 insertions(+), 1 deletion(-)
```

## Why this matters in practice

LLM coding agents using sapcli (e.g. Claude Code with the [sapcli plugin](https://github.com/jfilak/sapcli-claude-plugin)) currently have to regex on `ADTError` message text to differentiate "no suitable SC modifiable" from "wrong gCTS repo binding" from "object not found". With these subclasses, agents can branch by Python type and offer the right remediation (add `--record-changes`, escalate to repo admin, create-then-write, etc.) deterministically.

This PR is the upstream prerequisite for a transport-pick skill update on the plugin side.
