### PR TITLE
adt/objects: normalize CRLF in Class.Include.text

### DIFF
--- a/sap/adt/objects.py
+++ b/sap/adt/objects.py
@@ -1413,7 +1413,7 @@ class Class(OOADTObjectBase):
         def text(self):
             """Returns text"""
 
-            return self._clas.connection.get_text(f'{self.uri}{self._metadata.source_uri}')
+            return self._clas.connection.get_text(f'{self.uri}{self._metadata.source_uri}').replace('\r\n', '\n')
 
         def lock(self):
             """Calls parent's lock() for Class's open_editor()"""


### PR DESCRIPTION
## Summary

`Class.Include.text` (used when checking out a class's `testclasses`, `locals_def` and `locals_imp` includes) returned the raw response from ADT, which uses `\r\n` line endings. The base `ADTObject.text` (sap/adt/objects.py:723) has long normalized `\r\n` -> `\n` before returning; this override was missing the same call.

## Symptom (Windows)

`sap.cli.checkout` opens the target file in text mode (`open(filename, 'w', encoding='utf8')`). On Windows, text-mode write translates each `\n` -> `\r\n`. When the source already contains `\r\n`, the result on disk is `\r\r\n` -- every line renders with a blank line under it in VS Code and other editors.

Linux text-mode IO performs no translation, which is why the issue was invisible upstream.

## Fix

One-line change: append `.replace('\r\n', '\n')` to the override, mirroring the pattern already used by `ADTObject.text`. Same call, same semantics -- safe on Linux (no-op when there are no `\r\n` sequences).

## Files

- `sap/adt/objects.py` -- `Class.Include.text`
