### PR TITLE
http: add TLS client certificate authentication

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -7,7 +7,7 @@ a configuration file. The priority order from highest to lowest is:
 2. **Environment variables** - override config file values
 3. **Configuration file** (active context) - overrides defaults
 4. **Built-in defaults** - used when nothing else is specified
-5. **Interactive prompt** - fallback for mandatory values (user, password) when no SNC config is present, no valid OAuth token is cached, and no auth plugin is configured
+5. **Interactive prompt** - fallback for mandatory values (user, password) when no SNC config is present, no valid OAuth token is cached, and no auth plugin or client certificate is configured
 
 ## Parameters
 
@@ -166,6 +166,32 @@ config file. Precedence: CLI flag > env var > config file. The
 sapcli --auth-plugin-disable-cache abap systeminfo
 ```
 
+### --auth-cert
+
+Path to a PEM encoded X.509 client certificate used for TLS client
+certificate authentication (mTLS) instead of user/password. The file may
+also contain the private key - in that case `--auth-key` can be omitted.
+
+When a client certificate is configured, sapcli does not prompt for user
+or password - the server derives the user from the certificate.
+
+The certificate can also be set via the environment variable
+`SAP_AUTH_CERT` or via `auth_cert` in the configuration file. See
+[Client certificate authentication](#client-certificate-authentication).
+
+```bash
+sapcli --auth-cert ~/certs/me.crt --auth-key ~/certs/me.key abap systeminfo
+```
+
+### --auth-key
+
+Path to the PEM encoded private key belonging to `--auth-cert`. The key
+must not be password protected - see
+[Password protected keys](#password-protected-keys).
+
+The key can also be set via the environment variable `SAP_AUTH_KEY` or
+via `auth_key` in the configuration file.
+
 ## Configuration file
 
 ### File location
@@ -297,13 +323,23 @@ authentication. See [OAuth 2.0 authentication](#oauth-20-authentication) below.
 
 | Field | Type | Required | Default | Env var equivalent |
 |---|---|---|---|---|
-| `user` | string | yes | - | `SAP_USER` |
+| `user` | string | yes (*) | - | `SAP_USER` |
 | `password` | string | no | - | `SAP_PASSWORD` |
 | `auth_plugin` | mapping | no | - | (config only) |
+| `auth_cert` | string | no | - | `SAP_AUTH_CERT` |
+| `auth_key` | string | no | - | `SAP_AUTH_KEY` |
+
+(*) Not required when `auth_plugin` or `auth_cert` is used - the plugin
+acquires the credentials itself and the server derives the user from a
+client certificate.
 
 `auth_plugin` is mutually exclusive with `password` and with OAuth fields
 on the same logical session. See [Auth plugins](#auth-plugins) for the
 plugin contract and configuration shape.
+
+`auth_cert` is mutually exclusive with `password`, `auth_plugin`, and
+OAuth fields in the same resolved context. See
+[Client certificate authentication](#client-certificate-authentication).
 
 #### `contexts.<name>`
 
@@ -335,15 +371,18 @@ fields (e.g. hostname). Define one base connection and override per context.
 Storing passwords in plain text configuration files is a security concern.
 The recommended approaches, in order of preference:
 
-1. **Use OAuth 2.0** - if your system supports it (e.g. SAP cloud systems),
+1. **Use a client certificate** - if your system supports X.509 logon,
+   no secret needs to be stored at all. See
+   [Client certificate authentication](#client-certificate-authentication) below.
+2. **Use OAuth 2.0** - if your system supports it (e.g. SAP cloud systems),
    prefer OAuth over a stored password. See
    [OAuth 2.0 authentication](#oauth-20-authentication) below.
-2. **Use an auth plugin** - for SAML2 SSO, Windows client certificates,
+3. **Use an auth plugin** - for SAML2 SSO, certificates in secret stores,
    or any other method that does not fit OAuth or BasicAuth. See
    [Auth plugins](#auth-plugins) below.
-3. **Omit the password from config** - sapcli will prompt interactively
-4. **Use environment variables** - `SAP_PASSWORD` overrides the config file; suitable for CI/CD pipelines
-5. **Store in config file** - acceptable for local development if the file has restrictive permissions (`chmod 600`)
+4. **Omit the password from config** - sapcli will prompt interactively
+5. **Use environment variables** - `SAP_PASSWORD` overrides the config file; suitable for CI/CD pipelines
+6. **Store in config file** - acceptable for local development if the file has restrictive permissions (`chmod 600`)
 
 sapcli will warn if the config file is world-readable and contains passwords.
 
@@ -408,6 +447,77 @@ file:
 ```bash
 rm ~/.sapcli/tokens.json
 ```
+
+### Client certificate authentication
+
+SAP systems can authenticate users with X.509 client certificates
+(mutual TLS): the ICM maps the certificate's subject to an ABAP user, so
+no password is exchanged at all. sapcli presents the certificate when
+`--auth-cert`/`SAP_AUTH_CERT` or `auth_cert` in the configuration file
+is set.
+
+The certificate belongs to a **user** definition - it is an identity,
+not a property of a system. One certificate is typically accepted by
+many systems, which is expressed by referencing the same user from
+several contexts:
+
+```yaml
+connections:
+  dev-system:
+    ashost: dev.example.com
+    client: "100"
+
+  qas-system:
+    ashost: qas.example.com
+    client: "200"
+
+users:
+  cert-me:                        # note: no 'user' name needed
+    auth_cert: ~/certs/me.crt     # PEM certificate (may include the chain)
+    auth_key: ~/certs/me.key      # PEM private key, not password protected
+
+contexts:
+  dev:
+    connection: dev-system
+    user: cert-me
+  qas:
+    connection: qas-system
+    user: cert-me
+```
+
+Notes:
+
+- When the certificate file also contains the private key, omit
+  `auth_key` (the same convention as curl's `--cert` without `--key`).
+- If the server requires intermediate issuer certificates, append them
+  to the certificate file - there is no separate chain option.
+- Validation of the *server's* certificate is unrelated to client
+  certificate authentication and stays configured via
+  `--ssl-server-cert`/`ssl_server_cert` or the operating system trust
+  store.
+- A client certificate requires TLS - combining it with `--no-ssl` is
+  rejected.
+- `--user` may still be supplied as a hint for systems that map one
+  certificate to several users; it is optional.
+
+#### Password protected keys
+
+sapcli only accepts unencrypted private keys and refuses encrypted ones
+with an error. Storing the key passphrase in the configuration file
+would be equivalent to storing the key unencrypted, and prompting for
+the passphrase on every command would be impractical for scripting.
+
+Either decrypt the key into a file with restrictive permissions:
+
+```bash
+openssl pkey -in encrypted.key -out plain.key
+chmod 600 plain.key
+```
+
+or use an [auth plugin](#auth-plugins) with the `certificates` response
+type - a plugin can fetch the certificate from a secret store or decrypt
+the key with a passphrase from a keyring and hand sapcli ephemeral
+files.
 
 ### Auth plugins
 

--- a/sap/cli/__init__.py
+++ b/sap/cli/__init__.py
@@ -157,10 +157,11 @@ def adt_connection_from_args(args):
 def _build_session_initializer(args, conn_type=None, conn_path=None):
     """Pick the HTTPSessionInitializer for the given args.
 
-    Precedence: auth_plugin > OAuth > None (HTTPClient falls back to
-    BasicAuth). The three are mutually exclusive - the spec for
-    auth_plugin says so explicitly, and OAuth+plugin would be
-    nonsensical anyway since both want to own the session's auth.
+    Precedence: auth_plugin > client certificate > OAuth > None
+    (HTTPClient falls back to BasicAuth). The modes are mutually
+    exclusive - each wants to own the session's auth; the plugin outranks
+    the certificate because it is the designated escape hatch for advanced
+    certificate scenarios (secret stores, encrypted keys).
     """
 
     if getattr(args, 'auth_plugin', None):
@@ -169,6 +170,17 @@ def _build_session_initializer(args, conn_type=None, conn_path=None):
         # time we get here, args.password may have been populated from env
         # (the plugin's subprocess inherits it), and that is fine.
         return _build_plugin_initializer(args, conn_type, conn_path)
+
+    if getattr(args, 'auth_cert', None):
+        from sap.http.client_cert import ClientCertificateHTTPSessionInitializer
+
+        # No server_ca here - server trust stays owned by --ssl-server-cert,
+        # which HTTPClient.build_session applies after the initializer runs.
+        return ClientCertificateHTTPSessionInitializer(
+            args.auth_cert,
+            getattr(args, 'auth_key', None),
+            user=getattr(args, 'user', None),
+        )
 
     token_url = getattr(args, 'token_url', None)
     client_id = getattr(args, 'client_id', None)
@@ -349,6 +361,8 @@ def build_empty_connection_values():
         auth_plugin_cache_key=None,
         auth_plugin_disable_cache=None,
         auth_plugin_invalidate_cache=False,
+        auth_cert=None,
+        auth_key=None,
     )
 
 
@@ -433,6 +447,11 @@ def resolve_default_connection_values(args):
 
     _resolve_oauth_defaults(args, config_values)
 
+    # The certificate resolver must run before the plugin resolver - a
+    # higher-precedence certificate (CLI/env) switches the mode away from
+    # a config-file auth_plugin (see _resolve_auth_plugin_default).
+    _resolve_auth_cert_default(args, config_values)
+
     _resolve_auth_plugin_default(args, config_values)
 
     if hasattr(args, 'corrnr') and args.corrnr is None:
@@ -472,6 +491,66 @@ def _resolve_oauth_defaults(args, config_values):
         args.client_secret = os.getenv('SAP_CLIENT_SECRET') or config_values.get('client_secret')
 
 
+def _resolve_auth_cert_default(args, config_values):
+    """Resolve TLS client certificate authentication (auth_cert/auth_key)
+    with the usual per-field precedence: CLI args > env vars > config file.
+
+    Mutual exclusivity with password / auth_plugin / OAuth is enforced at
+    the *config* level only, mirroring _resolve_auth_plugin_default - an
+    exported SAP_PASSWORD must not poison a config-file certificate setup.
+    Across precedence levels the higher source silently selects the
+    authentication mode (e.g. --auth-cert beats a config-file auth_plugin).
+
+    Paths are ~-expanded - config files are shared between machines and
+    env vars may be set without shell expansion.
+    """
+
+    if not getattr(args, 'auth_cert', None):
+        args.auth_cert = os.getenv('SAP_AUTH_CERT')
+
+    if not getattr(args, 'auth_key', None):
+        args.auth_key = os.getenv('SAP_AUTH_KEY')
+
+    if args.auth_key:
+        args.auth_key = os.path.expanduser(args.auth_key)
+
+    if args.auth_cert:
+        # Certificate from CLI or env wins the mode; deliberately do not
+        # pull auth_key from config here - a cert from one source with a
+        # key from another is a mismatch waiting to happen.
+        args.auth_cert = os.path.expanduser(args.auth_cert)
+        return
+
+    cert = config_values.get('auth_cert')
+    if not cert:
+        return
+
+    if config_values.get('password'):
+        raise SAPCliConfigError(
+            "auth_cert and 'password' are mutually exclusive in the same "
+            "user definition. Remove 'password' from the user."
+        )
+
+    if config_values.get('auth_plugin'):
+        raise SAPCliConfigError(
+            "auth_cert and auth_plugin are mutually exclusive in the same "
+            "user definition."
+        )
+
+    if any(config_values.get(k) for k in ('token_url', 'client_id', 'client_secret')):
+        raise SAPCliConfigError(
+            "auth_cert and OAuth fields (token_url/client_id/client_secret) "
+            "are mutually exclusive."
+        )
+
+    args.auth_cert = os.path.expanduser(cert)
+
+    if not args.auth_key:
+        key = config_values.get('auth_key')
+        if key:
+            args.auth_key = os.path.expanduser(key)
+
+
 def _resolve_auth_plugin_default(args, config_values):
     """Resolve the auth_plugin definition from the config file and enforce
     its mutual exclusivity with password / OAuth at the *config* level.
@@ -494,7 +573,11 @@ def _resolve_auth_plugin_default(args, config_values):
         return
 
     plugin = config_values.get('auth_plugin')
-    if not plugin:
+    # A certificate resolved from a higher-precedence source (CLI/env)
+    # switches the mode away from a config-file plugin. The plugin+cert
+    # combination *within* the config is rejected by
+    # _resolve_auth_cert_default before this code runs.
+    if not plugin or getattr(args, 'auth_cert', None):
         args.auth_plugin = None
         args.auth_plugin_cache_key = None
         _resolve_disable_cache(args, None)

--- a/sap/cli/_entry.py
+++ b/sap/cli/_entry.py
@@ -63,6 +63,37 @@ def _system_cert_store_applies(args):
     )
 
 
+def _report_auth_cert_cli_conflicts(arg_parser, args):
+    """Reject contradictory authentication modes given on the command line.
+
+    Must run before resolve_default_connection_values merges in env/config
+    values - after that the sources are indistinguishable and e.g. an
+    exported SAP_PASSWORD must not trip the check.
+    """
+
+    if args.auth_cert and args.password:
+        report_args_error_and_exit(
+            arg_parser,
+            '--auth-cert and --password are mutually exclusive'
+            ': the client certificate replaces the password')
+
+
+def _report_auth_cert_resolved_conflicts(arg_parser, args):
+    """Reject broken client certificate setups after defaults resolution."""
+
+    if args.auth_key and not args.auth_cert:
+        report_args_error_and_exit(
+            arg_parser,
+            '--auth-key requires --auth-cert'
+            ' (or auth_cert in the configuration file)')
+
+    if args.auth_cert and not args.ssl:
+        report_args_error_and_exit(
+            arg_parser,
+            '--auth-cert cannot be used with --no-ssl'
+            ': a client certificate requires TLS')
+
+
 # pylint: disable=too-many-statements
 def parse_command_line(argv):
     """Parses command line arguments"""
@@ -93,6 +124,15 @@ def parse_command_line(argv):
         help='Do not read or write the auth-plugin response cache on disk '
              '(also drops any pre-existing entry). '
              'Env: SAPCLI_AUTH_PLUGIN_DISABLE_CACHE')
+    arg_parser.add_argument(
+        '--auth-cert', dest='auth_cert', type=str, default=None,
+        help='Path to a PEM client certificate for TLS client certificate '
+             'authentication; may contain the private key too. '
+             'Env: SAP_AUTH_CERT')
+    arg_parser.add_argument(
+        '--auth-key', dest='auth_key', type=str, default=None,
+        help='Path to the unencrypted PEM private key for --auth-cert. '
+             'Env: SAP_AUTH_KEY')
     arg_parser.add_argument(
         '--ashost', dest='ashost', type=str, default=None,
         help='Application Server address (DNS or IP)')
@@ -168,6 +208,8 @@ def parse_command_line(argv):
     if connection_factory is sap.cli.no_connection:
         return args
 
+    _report_auth_cert_cli_conflicts(arg_parser, args)
+
     sap.cli.resolve_default_connection_values(args)
 
     if _system_cert_store_applies(args):
@@ -196,11 +238,13 @@ def parse_command_line(argv):
                 'use the option --client or the environment variable SAP_CLIENT'
             )))
 
+    _report_auth_cert_resolved_conflicts(arg_parser, args)
+
     if not (args.snc_qop or args.snc_myname or args.snc_partnername):
-        # auth_plugin owns credential acquisition - do not prompt for either
-        # user or password. The plugin reads what it needs from its own
-        # source (env vars, browser, cert store, ...).
-        if not args.auth_plugin:
+        # auth_plugin owns credential acquisition and the server derives
+        # the user from a client certificate - do not prompt for either
+        # user or password in these modes.
+        if not args.auth_plugin and not args.auth_cert:
             if not args.user:
                 args.user = input('Login:')
 

--- a/sap/config.py
+++ b/sap/config.py
@@ -27,7 +27,7 @@ CONNECTION_FIELDS = (
 )
 
 USER_FIELDS = (
-    'user', 'password', 'auth_plugin',
+    'user', 'password', 'auth_plugin', 'auth_cert', 'auth_key',
 )
 
 CONTEXT_FIELDS = ()

--- a/sap/http/client_cert.py
+++ b/sap/http/client_cert.py
@@ -1,0 +1,84 @@
+"""HTTP session initializer for TLS client certificate (mTLS) authentication.
+
+The initializer only points requests at PEM files on disk - it never parses
+the cryptographic material itself. requests cannot use an encrypted private
+key (ssl.SSLContext.load_cert_chain is called without a password), so the
+key file is inspected for PEM encryption markers up front to fail with an
+actionable message instead of a cryptic OpenSSL error.
+"""
+
+import os
+
+from sap.errors import SAPCliError
+from sap.http.errors import UnauthorizedError
+
+
+_PEM_ENCRYPTION_MARKERS = (
+    b'BEGIN ENCRYPTED PRIVATE KEY',  # PKCS#8
+    b'Proc-Type: 4,ENCRYPTED',       # legacy PKCS#1
+)
+
+
+class ClientCertificateError(SAPCliError):
+    """Errors of TLS client certificate authentication configuration"""
+
+
+class ClientCertificateHTTPSessionInitializer:
+    """Populates sessions with a TLS client certificate (mTLS).
+
+    Implements the ``HTTPSessionInitializer`` protocol from
+    ``sap.http.client``. When ``key`` is None, ``certificate`` must be a
+    combined PEM file holding both the certificate and the private key
+    (curl's --cert without --key). Construction must not perform I/O -
+    plugin provided ephemeral files may only exist at initialize time.
+    """
+
+    def __init__(self, certificate, key=None, server_ca=None, user=None):
+        self._certificate = certificate
+        self._key = key
+        self._server_ca = server_ca
+        self._user = user
+
+    def initialize_session(self, session):
+        """Set the client certificate (and optionally the server CA) on the session"""
+
+        _check_file_exists(self._certificate, 'certificate')
+        if self._key:
+            _check_file_exists(self._key, 'key')
+
+        _check_key_not_encrypted(self._key or self._certificate)
+
+        if self._key:
+            session.cert = (self._certificate, self._key)
+        else:
+            session.cert = self._certificate
+
+        if self._server_ca:
+            session.verify = self._server_ca
+
+        return session
+
+    def build_unauthorized_error(self, req, res):
+        """Build an UnauthorizedError naming the user or the certificate file"""
+
+        return UnauthorizedError(req, res, self._user or f'client-cert:{self._certificate}')
+
+
+def _check_file_exists(path, role):
+    if not os.path.isfile(path):
+        raise ClientCertificateError(f'The client {role} file does not exist: {path}')
+
+
+def _check_key_not_encrypted(path):
+    try:
+        with open(path, 'rb') as key_file:
+            contents = key_file.read()
+    except OSError as ex:
+        raise ClientCertificateError(f'Cannot read the client key file {path}: {ex}') from ex
+
+    if any(marker in contents for marker in _PEM_ENCRYPTION_MARKERS):
+        raise ClientCertificateError(
+            f'The client private key is encrypted and sapcli cannot use it: {path}\n'
+            'Either decrypt it (openssl pkey -in encrypted.key -out plain.key)'
+            ' or use an auth plugin which provides an unencrypted key.'
+        )

--- a/sap/http/external_session_initializer.py
+++ b/sap/http/external_session_initializer.py
@@ -18,6 +18,7 @@ from sap.http.auth_plugin import (
     run_plugin,
 )
 from sap.http.auth_plugin_cache import get_response_store
+from sap.http.client_cert import ClientCertificateHTTPSessionInitializer
 from sap.http.errors import UnauthorizedError
 
 
@@ -167,11 +168,9 @@ def _apply_certificates(session, content: dict) -> None:
             "Plugin certificates response missing required field 'key'"
         )
 
-    session.cert = (certificate, key)
-
-    issuer = content.get('issuer_certificate')
-    if issuer:
-        session.verify = issuer
+    ClientCertificateHTTPSessionInitializer(
+        certificate, key, server_ca=content.get('issuer_certificate'),
+    ).initialize_session(session)
 
 
 _HANDLERS = {

--- a/test/unit/fixtures_sap_http_client_cert.py
+++ b/test/unit/fixtures_sap_http_client_cert.py
@@ -1,0 +1,38 @@
+"""PEM payloads for client certificate session initializer tests.
+
+The contents are structurally valid PEM blocks with dummy payloads - the
+initializer never parses the cryptographic material, it only inspects the
+PEM armor and headers.
+"""
+
+CERTIFICATE_PEM = '''-----BEGIN CERTIFICATE-----
+MIICdummycertificatepayloadAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+-----END CERTIFICATE-----
+'''
+
+PLAIN_KEY_PEM = '''-----BEGIN PRIVATE KEY-----
+MIIEdummyplainkeypayloadBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+-----END PRIVATE KEY-----
+'''
+
+ENCRYPTED_PKCS8_KEY_PEM = '''-----BEGIN ENCRYPTED PRIVATE KEY-----
+MIIFdummyencryptedkeypayloadCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+-----END ENCRYPTED PRIVATE KEY-----
+'''
+
+ENCRYPTED_LEGACY_KEY_PEM = '''-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: AES-128-CBC,0123456789ABCDEF0123456789ABCDEF
+
+MIIEdummylegacyencryptedkeypayloadDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD
+-----END RSA PRIVATE KEY-----
+'''
+
+COMBINED_CERT_AND_PLAIN_KEY_PEM = CERTIFICATE_PEM + PLAIN_KEY_PEM
+
+COMBINED_CERT_AND_ENCRYPTED_KEY_PEM = CERTIFICATE_PEM + ENCRYPTED_PKCS8_KEY_PEM
+
+SERVER_CA_PEM = '''-----BEGIN CERTIFICATE-----
+MIICdummyservercapayloadEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE
+-----END CERTIFICATE-----
+'''

--- a/test/unit/test_sap_cli.py
+++ b/test/unit/test_sap_cli.py
@@ -1556,5 +1556,281 @@ class TestBuildEmptyConnectionValuesDisableCache(unittest.TestCase):
         self.assertIsNone(values.auth_plugin_disable_cache)
 
 
+class TestBuildEmptyConnectionValuesAuthCert(unittest.TestCase):
+
+    def test_empty_values_include_auth_cert(self):
+        values = sap.cli.build_empty_connection_values()
+
+        self.assertTrue(hasattr(values, 'auth_cert'))
+        self.assertIsNone(values.auth_cert)
+
+    def test_empty_values_include_auth_key(self):
+        values = sap.cli.build_empty_connection_values()
+
+        self.assertTrue(hasattr(values, 'auth_key'))
+        self.assertIsNone(values.auth_key)
+
+
+class AuthCertArgsTestCase(unittest.TestCase):
+    """Base with the args namespace both resolver and factory tests need."""
+
+    def _make_args(self, **kwargs):
+        defaults = dict(
+            ashost=None, sysnr=None, client=None, port=None,
+            ssl=None, verify=None, ssl_server_cert=None,
+            user=None, password=None,
+            token_url=None, client_id=None, client_secret=None,
+            auth_plugin=None, auth_cert=None, auth_key=None,
+        )
+        defaults.update(kwargs)
+        return SimpleNamespace(**defaults)
+
+    def _config_with_user(self, user_def, connection_def=None):
+        return ConfigFile({
+            'current-context': 'ctx',
+            'connections': {
+                'srv': connection_def or {'ashost': 'h', 'client': '100'},
+            },
+            'users': {'u': user_def},
+            'contexts': {'ctx': {'connection': 'srv', 'user': 'u'}},
+        }, TEST_CONFIG_PATH)
+
+
+class TestResolveDefaultConnectionValuesAuthCert(AuthCertArgsTestCase):
+    """auth_cert/auth_key are propagated from the resolved config context
+       onto args (with ~ expansion) so the connection factory can build a
+       ClientCertificateHTTPSessionInitializer.
+    """
+
+    def test_auth_cert_propagated_from_config(self):
+        config_file = self._config_with_user({
+            'auth_cert': '/certs/me.crt',
+            'auth_key': '/certs/me.key',
+        })
+        args = self._make_args(config_file=config_file)
+
+        with patch.dict('os.environ', {}, clear=True):
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertEqual(args.auth_cert, '/certs/me.crt')
+        self.assertEqual(args.auth_key, '/certs/me.key')
+
+    def test_auth_cert_absent_when_not_in_config(self):
+        config_file = self._config_with_user({'user': 'USR', 'password': 'pwd'})
+        args = self._make_args(config_file=config_file)
+
+        with patch.dict('os.environ', {}, clear=True):
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertIsNone(args.auth_cert)
+        self.assertIsNone(args.auth_key)
+
+    def test_auth_cert_from_env(self):
+        config_file = self._config_with_user({'user': 'USR'})
+        args = self._make_args(config_file=config_file)
+
+        env = {
+            'SAP_AUTH_CERT': '/env/me.crt',
+            'SAP_AUTH_KEY': '/env/me.key',
+        }
+        with patch.dict('os.environ', env, clear=True):
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertEqual(args.auth_cert, '/env/me.crt')
+        self.assertEqual(args.auth_key, '/env/me.key')
+
+    def test_cli_args_beat_env_and_config(self):
+        config_file = self._config_with_user({
+            'auth_cert': '/cfg/me.crt',
+            'auth_key': '/cfg/me.key',
+        })
+        args = self._make_args(
+            config_file=config_file,
+            auth_cert='/cli/me.crt',
+            auth_key='/cli/me.key',
+        )
+
+        env = {
+            'SAP_AUTH_CERT': '/env/me.crt',
+            'SAP_AUTH_KEY': '/env/me.key',
+        }
+        with patch.dict('os.environ', env, clear=True):
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertEqual(args.auth_cert, '/cli/me.crt')
+        self.assertEqual(args.auth_key, '/cli/me.key')
+
+    def test_config_paths_are_user_expanded(self):
+        config_file = self._config_with_user({
+            'auth_cert': '~/certs/me.crt',
+            'auth_key': '~/certs/me.key',
+        })
+        args = self._make_args(config_file=config_file)
+
+        env = {'HOME': '/home/elbezi'}
+        with patch.dict('os.environ', env, clear=True):
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertEqual(args.auth_cert, '/home/elbezi/certs/me.crt')
+        self.assertEqual(args.auth_key, '/home/elbezi/certs/me.key')
+
+
+class TestResolveAuthCertMutualExclusivity(AuthCertArgsTestCase):
+    """auth_cert must conflict with password / auth_plugin / OAuth fields
+       at the config level (when they appear together in a resolved
+       context), not at the args level - mirroring auth_plugin so env vars
+       cannot trip the check.
+    """
+
+    def test_password_with_auth_cert_in_user_raises(self):
+        config_file = self._config_with_user({
+            'password': 'secret',
+            'auth_cert': '/certs/me.crt',
+        })
+        args = self._make_args(config_file=config_file)
+
+        with patch.dict('os.environ', {}, clear=True), \
+             self.assertRaises(SAPCliConfigError) as cm:
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertIn('mutually exclusive', str(cm.exception).lower())
+
+    def test_auth_plugin_with_auth_cert_in_user_raises(self):
+        config_file = self._config_with_user({
+            'auth_cert': '/certs/me.crt',
+            'auth_plugin': {'command': '/p'},
+        })
+        args = self._make_args(config_file=config_file)
+
+        with patch.dict('os.environ', {}, clear=True), \
+             self.assertRaises(SAPCliConfigError) as cm:
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertIn('mutually exclusive', str(cm.exception).lower())
+
+    def test_oauth_fields_with_auth_cert_raises(self):
+        config_file = self._config_with_user(
+            {'auth_cert': '/certs/me.crt'},
+            connection_def={
+                'ashost': 'h', 'client': '100',
+                'token_url': 'https://t', 'client_id': 'cid',
+                'client_secret': 'csec',
+            },
+        )
+        args = self._make_args(config_file=config_file)
+
+        with patch.dict('os.environ', {}, clear=True), \
+             self.assertRaises(SAPCliConfigError) as cm:
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertIn('mutually exclusive', str(cm.exception).lower())
+
+    def test_env_password_with_config_auth_cert_is_fine(self):
+        # Mode selection follows precedence - an exported SAP_PASSWORD
+        # must not poison a config-file certificate setup.
+        config_file = self._config_with_user({'auth_cert': '/certs/me.crt'})
+        args = self._make_args(config_file=config_file)
+
+        env = {'SAP_PASSWORD': 'exported'}
+        with patch.dict('os.environ', env, clear=True):
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertEqual(args.auth_cert, '/certs/me.crt')
+
+    def test_cli_auth_cert_overrides_config_auth_plugin(self):
+        # CLI > config: an explicit --auth-cert switches the mode away
+        # from a config-file auth_plugin instead of erroring out.
+        config_file = self._config_with_user({
+            'auth_plugin': {'command': '/p'},
+        })
+        args = self._make_args(config_file=config_file, auth_cert='/cli/me.crt')
+
+        with patch.dict('os.environ', {}, clear=True):
+            sap.cli.resolve_default_connection_values(args)
+
+        self.assertEqual(args.auth_cert, '/cli/me.crt')
+        self.assertIsNone(args.auth_plugin)
+
+
+class TestAuthCertSessionInitializer(AuthCertArgsTestCase):
+    """adt_connection_from_args must construct a
+       ClientCertificateHTTPSessionInitializer when args.auth_cert is set.
+    """
+
+    def _make_connection_args(self, **overrides):
+        defaults = dict(
+            ashost='h.example.com', client='100', user=None, password=None,
+            port=443, ssl=True, verify=True, ssl_server_cert=None,
+            token_url=None, client_id=None, client_secret=None,
+            auth_plugin=None, auth_cert=None, auth_key=None,
+        )
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def test_cert_initializer_when_auth_cert_set(self):
+        from sap.http.client_cert import ClientCertificateHTTPSessionInitializer
+
+        args = self._make_connection_args(
+            auth_cert='/certs/me.crt', auth_key='/certs/me.key', user='ELBEZI',
+        )
+
+        with patch('sap.adt.Connection') as mock_connection:
+            sap.cli.adt_connection_from_args(args)
+
+        _, kwargs = mock_connection.call_args
+        initializer = kwargs.get('session_initializer')
+        self.assertIsInstance(initializer, ClientCertificateHTTPSessionInitializer)
+        self.assertEqual(initializer._certificate, '/certs/me.crt')
+        self.assertEqual(initializer._key, '/certs/me.key')
+        self.assertIsNone(initializer._server_ca)
+        self.assertEqual(initializer._user, 'ELBEZI')
+
+    def test_cert_initializer_without_key(self):
+        from sap.http.client_cert import ClientCertificateHTTPSessionInitializer
+
+        args = self._make_connection_args(auth_cert='/certs/me.pem')
+
+        with patch('sap.adt.Connection') as mock_connection:
+            sap.cli.adt_connection_from_args(args)
+
+        _, kwargs = mock_connection.call_args
+        initializer = kwargs.get('session_initializer')
+        self.assertIsInstance(initializer, ClientCertificateHTTPSessionInitializer)
+        self.assertEqual(initializer._certificate, '/certs/me.pem')
+        self.assertIsNone(initializer._key)
+
+    def test_auth_plugin_beats_auth_cert(self):
+        from sap.http.external_session_initializer import (
+            HTTPExternalSessionInitializer,
+        )
+
+        args = self._make_connection_args(
+            auth_plugin={'command': '/p'},
+            auth_cert='/certs/me.crt',
+        )
+
+        with patch('sap.adt.Connection') as mock_connection:
+            sap.cli.adt_connection_from_args(args)
+
+        _, kwargs = mock_connection.call_args
+        self.assertIsInstance(
+            kwargs.get('session_initializer'), HTTPExternalSessionInitializer)
+
+    def test_auth_cert_beats_oauth(self):
+        from sap.http.client_cert import ClientCertificateHTTPSessionInitializer
+
+        args = self._make_connection_args(
+            auth_cert='/certs/me.crt',
+            token_url='https://t', client_id='cid', client_secret='csec',
+        )
+
+        with patch('sap.adt.Connection') as mock_connection:
+            sap.cli.adt_connection_from_args(args)
+
+        _, kwargs = mock_connection.call_args
+        self.assertIsInstance(
+            kwargs.get('session_initializer'), ClientCertificateHTTPSessionInitializer)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_sap_cli__entry.py
+++ b/test/unit/test_sap_cli__entry.py
@@ -471,6 +471,143 @@ class TestParseCommandLine(unittest.TestCase):
             self.assertFalse(args.auth_plugin_disable_cache, msg=variant)
 
 
+class TestParseCommandLineAuthCert(unittest.TestCase):
+
+    def setUp(self):
+        self._get_commands_patcher = patch('sap.cli.get_commands')
+        fake_commands = self._get_commands_patcher.start()
+        self._fake_cmd = make_mock_command()
+        fake_commands.return_value = [(Mock(), self._fake_cmd)]
+
+        self._config_patcher = patch('sap.cli._entry.ConfigFile.load', return_value=ConfigFile({}, TEST_CONFIG_PATH))
+        self._config_patcher.start()
+
+    def tearDown(self):
+        self._config_patcher.stop()
+        self._get_commands_patcher.stop()
+
+    def _cert_parameters(self, *extra):
+        """Tested parameters without user/password/no-ssl, with the given
+           extra global options inserted before the command name."""
+
+        params = get_tested_parameters()
+        remove_cmd_param_from_list(params, '--user')
+        remove_cmd_param_from_list(params, '--password')
+        params.remove('--no-ssl')
+        params[1:1] = list(extra)
+        return params
+
+    def test_args_auth_cert_and_key_skip_prompts(self):
+        params = self._cert_parameters(
+            '--auth-cert', '/certs/me.crt', '--auth-key', '/certs/me.key')
+
+        getpass_mock = Mock(return_value='should-not-be-used')
+        input_mock = Mock(return_value='should-not-be-used')
+
+        with patch('getpass.getpass', getpass_mock), \
+             patch('builtins.input', input_mock):
+            args = entry.parse_command_line(params)
+
+        getpass_mock.assert_not_called()
+        input_mock.assert_not_called()
+        self.assertEqual(args.auth_cert, '/certs/me.crt')
+        self.assertEqual(args.auth_key, '/certs/me.key')
+        self.assertIsNone(args.user)
+        self.assertIsNone(args.password)
+
+    def test_args_auth_cert_without_key_is_combined_file(self):
+        params = self._cert_parameters('--auth-cert', '/certs/me.pem')
+
+        with patch('builtins.input', Mock(return_value='unused')):
+            args = entry.parse_command_line(params)
+
+        self.assertEqual(args.auth_cert, '/certs/me.pem')
+        self.assertIsNone(args.auth_key)
+
+    def test_args_auth_cert_with_user_is_allowed(self):
+        # Some servers map one certificate to several users via login
+        # modules and honor a user hint - the combination is legal.
+        params = self._cert_parameters(
+            '--auth-cert', '/certs/me.crt', '--user', 'fantomas')
+
+        args = entry.parse_command_line(params)
+
+        self.assertEqual(args.auth_cert, '/certs/me.crt')
+        self.assertEqual(args.user, 'fantomas')
+
+    def test_args_auth_key_without_auth_cert_errors(self):
+        params = self._cert_parameters('--auth-key', '/certs/me.key')
+
+        with patch('sys.stderr', new_callable=StringIO) as fake_output, \
+             self.assertRaises(SystemExit) as exit_cm:
+            entry.parse_command_line(params)
+
+        self.assertEqual(str(exit_cm.exception), '3')
+        self.assertIn('--auth-cert', fake_output.getvalue())
+
+    def test_args_auth_cert_with_password_errors(self):
+        params = self._cert_parameters(
+            '--auth-cert', '/certs/me.crt', '--password', 'Down1oad')
+
+        with patch('sys.stderr', new_callable=StringIO) as fake_output, \
+             self.assertRaises(SystemExit) as exit_cm:
+            entry.parse_command_line(params)
+
+        self.assertEqual(str(exit_cm.exception), '3')
+        self.assertIn('mutually exclusive', fake_output.getvalue())
+
+    def test_args_auth_cert_with_no_ssl_errors(self):
+        params = self._cert_parameters('--auth-cert', '/certs/me.crt', '--no-ssl')
+
+        with patch('sys.stderr', new_callable=StringIO) as fake_output, \
+             self.assertRaises(SystemExit) as exit_cm:
+            entry.parse_command_line(params)
+
+        self.assertEqual(str(exit_cm.exception), '3')
+        self.assertIn('TLS', fake_output.getvalue())
+
+    def test_args_skip_prompts_when_config_auth_cert(self):
+        """When the resolved context configures auth_cert, the user prompt
+           and the password prompt must both be suppressed - the server
+           derives the user from the certificate.
+        """
+
+        config_data = {
+            'current-context': 'cert-ctx',
+            'connections': {
+                'server': {'ashost': 'h.example.com', 'client': '100'},
+            },
+            'users': {
+                'cert-user': {'auth_cert': '/certs/me.crt'},
+            },
+            'contexts': {
+                'cert-ctx': {'connection': 'server', 'user': 'cert-user'},
+            },
+        }
+        self._config_patcher.stop()
+        self._config_patcher = patch(
+            'sap.cli._entry.ConfigFile.load',
+            return_value=ConfigFile(config_data, TEST_CONFIG_PATH),
+        )
+        self._config_patcher.start()
+
+        params = self._cert_parameters()
+        remove_cmd_param_from_list(params, '--ashost')
+        remove_cmd_param_from_list(params, '--client')
+
+        getpass_mock = Mock(return_value='should-not-be-used')
+        input_mock = Mock(return_value='should-not-be-used')
+
+        with patch('getpass.getpass', getpass_mock), \
+             patch('builtins.input', input_mock):
+            args = entry.parse_command_line(params)
+
+        getpass_mock.assert_not_called()
+        input_mock.assert_not_called()
+        self.assertEqual(args.auth_cert, '/certs/me.crt')
+        self.assertIsNone(args.password)
+
+
 class TestParseCommandLineNoCommand(unittest.TestCase):
 
     @patch('sap.cli._entry.ConfigFile.load', return_value=ConfigFile({}, TEST_CONFIG_PATH))

--- a/test/unit/test_sap_http_client_cert.py
+++ b/test/unit/test_sap_http_client_cert.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock
+
+import requests
+
+from sap.errors import SAPCliError
+from sap.http.client import HTTPSessionInitializer
+from sap.http.client_cert import (
+    ClientCertificateError,
+    ClientCertificateHTTPSessionInitializer,
+)
+from sap.http.errors import UnauthorizedError
+
+from fixtures_sap_http_client_cert import (
+    CERTIFICATE_PEM,
+    COMBINED_CERT_AND_ENCRYPTED_KEY_PEM,
+    COMBINED_CERT_AND_PLAIN_KEY_PEM,
+    ENCRYPTED_LEGACY_KEY_PEM,
+    ENCRYPTED_PKCS8_KEY_PEM,
+    PLAIN_KEY_PEM,
+    SERVER_CA_PEM,
+)
+
+
+class ClientCertFilesTestCase(unittest.TestCase):
+    """Base providing on-disk PEM files for initializer tests."""
+
+    def setUp(self):
+        # pylint: disable=consider-using-with
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp_dir.cleanup)
+
+    def _write(self, name, content):
+        path = os.path.join(self._tmp_dir.name, name)
+        with open(path, 'w', encoding='ascii') as pem_file:
+            pem_file.write(content)
+
+        return path
+
+
+class TestConstruction(ClientCertFilesTestCase):
+
+    def test_satisfies_session_initializer_protocol(self):
+        initializer = ClientCertificateHTTPSessionInitializer('/cert.pem', '/key.pem')
+
+        self.assertIsInstance(initializer, HTTPSessionInitializer)
+
+    def test_error_derives_from_sapclierror(self):
+        self.assertTrue(issubclass(ClientCertificateError, SAPCliError))
+
+    def test_construction_does_no_io(self):
+        # Constructing with non-existent paths must not raise - plugin
+        # provided ephemeral files may only exist at initialize time.
+        ClientCertificateHTTPSessionInitializer(
+            '/does/not/exist.pem', '/does/not/exist.key'
+        )
+
+
+class TestInitializeSession(ClientCertFilesTestCase):
+
+    def test_certificate_and_key_set_session_cert_tuple(self):
+        cert = self._write('client.crt', CERTIFICATE_PEM)
+        key = self._write('client.key', PLAIN_KEY_PEM)
+        session = requests.Session()
+
+        initializer = ClientCertificateHTTPSessionInitializer(cert, key)
+        returned = initializer.initialize_session(session)
+
+        self.assertIs(returned, session)
+        self.assertEqual(session.cert, (cert, key))
+
+    def test_combined_file_without_key_sets_session_cert_path(self):
+        combined = self._write('client.pem', COMBINED_CERT_AND_PLAIN_KEY_PEM)
+        session = requests.Session()
+
+        ClientCertificateHTTPSessionInitializer(combined).initialize_session(session)
+
+        self.assertEqual(session.cert, combined)
+
+    def test_server_ca_sets_session_verify(self):
+        cert = self._write('client.crt', CERTIFICATE_PEM)
+        key = self._write('client.key', PLAIN_KEY_PEM)
+        server_ca = self._write('ca.pem', SERVER_CA_PEM)
+        session = requests.Session()
+
+        ClientCertificateHTTPSessionInitializer(
+            cert, key, server_ca=server_ca
+        ).initialize_session(session)
+
+        self.assertEqual(session.verify, server_ca)
+
+    def test_no_server_ca_leaves_session_verify_untouched(self):
+        cert = self._write('client.crt', CERTIFICATE_PEM)
+        key = self._write('client.key', PLAIN_KEY_PEM)
+        session = requests.Session()
+
+        ClientCertificateHTTPSessionInitializer(cert, key).initialize_session(session)
+
+        self.assertIs(session.verify, True)
+
+    def test_missing_certificate_file_raises(self):
+        key = self._write('client.key', PLAIN_KEY_PEM)
+        missing = os.path.join(self._tmp_dir.name, 'nosuch.crt')
+
+        initializer = ClientCertificateHTTPSessionInitializer(missing, key)
+
+        with self.assertRaisesRegex(ClientCertificateError, 'nosuch.crt'):
+            initializer.initialize_session(requests.Session())
+
+    def test_missing_key_file_raises(self):
+        cert = self._write('client.crt', CERTIFICATE_PEM)
+        missing = os.path.join(self._tmp_dir.name, 'nosuch.key')
+
+        initializer = ClientCertificateHTTPSessionInitializer(cert, missing)
+
+        with self.assertRaisesRegex(ClientCertificateError, 'nosuch.key'):
+            initializer.initialize_session(requests.Session())
+
+
+class TestEncryptedKeyDetection(ClientCertFilesTestCase):
+
+    def test_encrypted_pkcs8_key_raises(self):
+        cert = self._write('client.crt', CERTIFICATE_PEM)
+        key = self._write('client.key', ENCRYPTED_PKCS8_KEY_PEM)
+
+        initializer = ClientCertificateHTTPSessionInitializer(cert, key)
+
+        with self.assertRaisesRegex(ClientCertificateError, 'encrypted'):
+            initializer.initialize_session(requests.Session())
+
+    def test_encrypted_legacy_key_raises(self):
+        cert = self._write('client.crt', CERTIFICATE_PEM)
+        key = self._write('client.key', ENCRYPTED_LEGACY_KEY_PEM)
+
+        initializer = ClientCertificateHTTPSessionInitializer(cert, key)
+
+        with self.assertRaisesRegex(ClientCertificateError, 'encrypted'):
+            initializer.initialize_session(requests.Session())
+
+    def test_encrypted_key_error_names_the_way_out(self):
+        cert = self._write('client.crt', CERTIFICATE_PEM)
+        key = self._write('client.key', ENCRYPTED_PKCS8_KEY_PEM)
+
+        initializer = ClientCertificateHTTPSessionInitializer(cert, key)
+
+        with self.assertRaisesRegex(ClientCertificateError, 'auth plugin'):
+            initializer.initialize_session(requests.Session())
+
+    def test_encrypted_key_in_combined_file_raises(self):
+        combined = self._write('client.pem', COMBINED_CERT_AND_ENCRYPTED_KEY_PEM)
+
+        initializer = ClientCertificateHTTPSessionInitializer(combined)
+
+        with self.assertRaisesRegex(ClientCertificateError, 'encrypted'):
+            initializer.initialize_session(requests.Session())
+
+    def test_encrypted_key_does_not_touch_session(self):
+        cert = self._write('client.crt', CERTIFICATE_PEM)
+        key = self._write('client.key', ENCRYPTED_PKCS8_KEY_PEM)
+        session = requests.Session()
+
+        initializer = ClientCertificateHTTPSessionInitializer(cert, key)
+
+        with self.assertRaises(ClientCertificateError):
+            initializer.initialize_session(session)
+
+        self.assertIsNone(session.cert)
+
+
+class TestBuildUnauthorizedError(ClientCertFilesTestCase):
+
+    def test_with_user_carries_user(self):
+        initializer = ClientCertificateHTTPSessionInitializer(
+            '/cert.pem', '/key.pem', user='alice'
+        )
+        req = Mock()
+        res = Mock()
+
+        err = initializer.build_unauthorized_error(req, res)
+
+        self.assertIsInstance(err, UnauthorizedError)
+        self.assertIs(err.request, req)
+        self.assertIs(err.response, res)
+        self.assertEqual(err.user, 'alice')
+
+    def test_without_user_names_certificate(self):
+        initializer = ClientCertificateHTTPSessionInitializer('/cert.pem', '/key.pem')
+
+        err = initializer.build_unauthorized_error(Mock(), Mock())
+
+        self.assertEqual(err.user, 'client-cert:/cert.pem')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_sap_http_external_session_initializer.py
+++ b/test/unit/test_sap_http_external_session_initializer.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import os
+import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
@@ -12,8 +14,16 @@ from sap.http.auth_plugin import (
     ConnectionInfo,
 )
 from sap.http.client import HTTPClient, HTTPSessionInitializer
+from sap.http.client_cert import ClientCertificateError
 from sap.http.errors import UnauthorizedError
 from sap.http.external_session_initializer import HTTPExternalSessionInitializer
+
+from fixtures_sap_http_client_cert import (
+    CERTIFICATE_PEM,
+    ENCRYPTED_PKCS8_KEY_PEM,
+    PLAIN_KEY_PEM,
+    SERVER_CA_PEM,
+)
 
 
 def _connection():
@@ -243,6 +253,18 @@ class TestHeaderDispatch(unittest.TestCase):
 
 class TestCertificatesDispatch(unittest.TestCase):
 
+    def setUp(self):
+        # pylint: disable=consider-using-with
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp_dir.cleanup)
+
+    def _write(self, name, content):
+        path = os.path.join(self._tmp_dir.name, name)
+        with open(path, 'w', encoding='ascii') as pem_file:
+            pem_file.write(content)
+
+        return path
+
     def _initialize(self, content):
         with patch(
             'sap.http.external_session_initializer.run_plugin',
@@ -256,36 +278,69 @@ class TestCertificatesDispatch(unittest.TestCase):
             return session
 
     def test_certificate_and_key_set_session_cert(self):
+        cert = self._write('client.crt', CERTIFICATE_PEM)
+        key = self._write('client.key', PLAIN_KEY_PEM)
+
         session = self._initialize({
             'type': 'certificates',
-            'certificate': '/etc/ssl/client.pem',
-            'key': '/etc/ssl/client.key',
+            'certificate': cert,
+            'key': key,
         })
 
-        self.assertEqual(session.cert, ('/etc/ssl/client.pem', '/etc/ssl/client.key'))
+        self.assertEqual(session.cert, (cert, key))
 
     def test_issuer_certificate_sets_session_verify(self):
+        cert = self._write('client.crt', CERTIFICATE_PEM)
+        key = self._write('client.key', PLAIN_KEY_PEM)
+        issuer = self._write('ca.pem', SERVER_CA_PEM)
+
         session = self._initialize({
             'type': 'certificates',
-            'certificate': '/etc/ssl/client.pem',
-            'key': '/etc/ssl/client.key',
-            'issuer_certificate': '/etc/ssl/ca.pem',
+            'certificate': cert,
+            'key': key,
+            'issuer_certificate': issuer,
         })
 
-        self.assertEqual(session.verify, '/etc/ssl/ca.pem')
+        self.assertEqual(session.verify, issuer)
 
     def test_missing_certificate_raises(self):
+        key = self._write('client.key', PLAIN_KEY_PEM)
+
         with self.assertRaisesRegex(AuthPluginError, "certificate"):
             self._initialize({
                 'type': 'certificates',
-                'key': '/etc/ssl/client.key',
+                'key': key,
             })
 
     def test_missing_key_raises(self):
+        cert = self._write('client.crt', CERTIFICATE_PEM)
+
         with self.assertRaisesRegex(AuthPluginError, "key"):
             self._initialize({
                 'type': 'certificates',
-                'certificate': '/etc/ssl/client.pem',
+                'certificate': cert,
+            })
+
+    def test_nonexistent_certificate_file_raises(self):
+        key = self._write('client.key', PLAIN_KEY_PEM)
+        missing = os.path.join(self._tmp_dir.name, 'nosuch.crt')
+
+        with self.assertRaisesRegex(ClientCertificateError, 'nosuch.crt'):
+            self._initialize({
+                'type': 'certificates',
+                'certificate': missing,
+                'key': key,
+            })
+
+    def test_encrypted_key_file_raises(self):
+        cert = self._write('client.crt', CERTIFICATE_PEM)
+        key = self._write('client.key', ENCRYPTED_PKCS8_KEY_PEM)
+
+        with self.assertRaisesRegex(ClientCertificateError, 'encrypted'):
+            self._initialize({
+                'type': 'certificates',
+                'certificate': cert,
+                'key': key,
             })
 
 


### PR DESCRIPTION
Add the command line parameters --auth-cert and --auth-key, the env vars SAP_AUTH_CERT and SAP_AUTH_KEY, and the user configuration fields auth_cert and auth_key which configure mutual TLS for HTTP connections (ADT, gCTS REST, OData) via the new
ClientCertificateHTTPSessionInitializer.

The initializer is reused by the auth-plugin certificates content type applier, so both paths share the file existence check and the early refusal of password protected private keys (requests cannot load encrypted keys; plugins are the escape hatch for secret stores).

The certificate replaces user/password: prompts are suppressed, and the mode is mutually exclusive with password, auth_plugin, and OAuth within the same precedence level while CLI > env > config selects the mode across levels.