### PR TITLE
Add hint for installing sapcli.exe to a custom folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ Finally install **sapcli**:
 
 #### Installing sapcli.exe to a custom folder
 
-If you want `sapcli.exe` to be placed in a specific folder instead of the default
-`%USERPROFILE%\.local\bin`, set the `PIPX_BIN_DIR` environment variable before
+By default, pipx places `sapcli.exe` in `%USERPROFILE%\.local\bin`. If that folder
+is scanned by Microsoft Defender (or another antivirus tool) and causes performance
+issues or blocks execution, you can install `sapcli.exe` into a folder that is
+excluded from scanning instead. Set the `PIPX_BIN_DIR` environment variable before
 running the install command:
 
 ```cmd

--- a/README.md
+++ b/README.md
@@ -112,6 +112,26 @@ Finally install **sapcli**:
 - Run: `pipx install <the copied link>`
 - Verify the installation by running: `sapcli --version`
 
+#### Installing sapcli.exe to a custom folder
+
+If you want `sapcli.exe` to be placed in a specific folder instead of the default
+`%USERPROFILE%\.local\bin`, set the `PIPX_BIN_DIR` environment variable before
+running the install command:
+
+```cmd
+set PIPX_BIN_DIR=C:\<your-folder>\sapcli
+pipx install <the copied link>
+```
+
+Afterwards, make sure `C:\<your-folder>\sapcli` is on your PATH, or run:
+
+```cmd
+pipx ensurepath
+```
+
+`PIPX_BIN_DIR` only controls where the `sapcli.exe` shim is placed — the Python
+virtual environment remains in `%USERPROFILE%\pipx\venvs\sapcli`.
+
 ### Enable RFC features
 
 RFC features are not enabled until you install the required dependencies, but sapcli is perfectly operational even without them because the other features only need HTTP connectivity.


### PR DESCRIPTION
Adds a hint explaining how to install sapcli.exe to a custom folder by setting PIPX_BIN_DIR before running pipx install. This is useful when the default %USERPROFILE%\.local\bin is scanned by Microsoft Defender and you need the executable in an excluded folder.